### PR TITLE
Idc fix

### DIFF
--- a/include/rbdl/Constraints.h
+++ b/include/rbdl/Constraints.h
@@ -528,7 +528,6 @@ struct RBDL_DLLAPI ConstraintSet {
   Math::VectorNd qddot_z;
 
   Math::MatrixNd AIdc;
-  Math::MatrixNd KIdc;
   Math::VectorNd bIdc;
   Math::VectorNd xIdc;
   Math::VectorNd vIdc;

--- a/include/rbdl/Constraints.h
+++ b/include/rbdl/Constraints.h
@@ -496,7 +496,10 @@ struct RBDL_DLLAPI ConstraintSet {
   Math::VectorNd v;
 
   Math::MatrixNd F;
+  Math::MatrixNd Ful,Fur,Fll,Flr; //blocks of f for SimpleMath
+
   Math::MatrixNd GT;
+  Math::MatrixNd GTu, GTl;//blocks of GT for SimpleMath
   Math::VectorNd g;
   Math::MatrixNd Ru;
   Math::VectorNd py;
@@ -527,13 +530,7 @@ struct RBDL_DLLAPI ConstraintSet {
   Math::VectorNd qddot_y;
   Math::VectorNd qddot_z;
 
-  Math::MatrixNd AIdc;
-  Math::VectorNd bIdc;
-  Math::VectorNd xIdc;
-  Math::VectorNd vIdc;
-  Math::VectorNd wIdc;
   // Variables used by the IABI methods
-
   /// Workspace for the Inverse Articulated-Body Inertia.
   Math::MatrixNd K;
   /// Workspace for the accelerations of due to the test forces
@@ -1246,13 +1243,10 @@ By projecting this onto the onto the \f$S\f$ and \f$P\f$ spaces
   \f[
      \text{rank}( GP^T ) = n - n_a.
   \f]
-
- \note The implementation is currently a prototype method, and as such, can
-       be greatly sped up. If you refer to Eqn. 5.20 in Koch's thesis the
-       current implementation is solving the \f$(n+n_c+n_a)\times(n+n_c+n_a)\f$
-       matrix directly. This block diagonal matrix can be solved in parts much
-       faster.
-
+  The implementation exploits the triangular structure of the matrix which
+  means that only two linear systems of size \f$(c \times u)\f$ and
+  \f$(u \times c)\f$ are performed which is much faster than solving the
+  \f$(2n \times 2n)\f$ KKT matrix directly.
 
 
  <b>References</b>
@@ -1279,7 +1273,7 @@ By projecting this onto the onto the \f$S\f$ and \f$P\f$ spaces
 
 
 */
-
+#ifndef RBDL_USE_SIMPLE_MATH
 RBDL_DLLAPI
 void InverseDynamicsConstraints(
     Model &model,
@@ -1290,8 +1284,8 @@ void InverseDynamicsConstraints(
     Math::VectorNd &QDDotOutput,
     Math::VectorNd &TauOutput,
     std::vector<Math::SpatialVector> *f_ext  = NULL);
+#endif
 
-#ifndef RBDL_USE_SIMPLE_MATH
 /**
   \brief A method to evaluate if the constrained system is fully actuated.
 
@@ -1313,6 +1307,7 @@ void InverseDynamicsConstraints(
  \param f_ext External forces acting on the body in base coordinates
         (optional, defaults to NULL)
 */
+#ifndef RBDL_USE_SIMPLE_MATH
 RBDL_DLLAPI 
 bool isConstrainedSystemFullyActuated(
     Model &model,

--- a/include/rbdl/Constraints.h
+++ b/include/rbdl/Constraints.h
@@ -492,6 +492,8 @@ struct RBDL_DLLAPI ConstraintSet {
   /// accelerations
   Math::MatrixNd W;
   Math::MatrixNd Winv;
+  Math::VectorNd WinvSC;
+
   Math::VectorNd u;
   Math::VectorNd v;
 

--- a/include/rbdl/Constraints.h
+++ b/include/rbdl/Constraints.h
@@ -522,6 +522,14 @@ struct RBDL_DLLAPI ConstraintSet {
   Math::VectorNd qddot_y;
   Math::VectorNd qddot_z;
 
+  Math::MatrixNd AIdcD;
+  Math::MatrixNd KIdcD;
+  Math::VectorNd bIdcD;
+  Math::VectorNd xIdcD;
+  Math::VectorNd vIdcD;
+  Math::VectorNd wIdcD;
+
+
   // Variables used by the IABI methods
 
   /// Workspace for the Inverse Articulated-Body Inertia.
@@ -1106,6 +1114,17 @@ accelerations, \f$\ddot{q}^*\f$, and the actuated accelerations is minimized
  */
 RBDL_DLLAPI
 void InverseDynamicsConstraints(
+    Model &model,
+    const Math::VectorNd &Q,
+    const Math::VectorNd &QDot,
+    const Math::VectorNd &QDDotDesired,
+    ConstraintSet &CS,
+    Math::VectorNd &QDDotOutput,
+    Math::VectorNd &TauOutput,
+    std::vector<Math::SpatialVector> *f_ext  = NULL);
+
+RBDL_DLLAPI
+void InverseDynamicsConstraintsFullyActuated(
     Model &model,
     const Math::VectorNd &Q,
     const Math::VectorNd &QDot,

--- a/tests/InverseDynamicsWithConstraintsTests.cc
+++ b/tests/InverseDynamicsWithConstraintsTests.cc
@@ -95,8 +95,19 @@ TEST(CorrectnessTestWithSinglePlanarPendulum){
   //The IDC operator should be able to statisfy qdd=0 and return a tau
   //vector that matches the hand solution produced above.
   spa.cs.SetActuationMap(spa.model,actuationMap);
-  InverseDynamicsConstraintsFullyActuated(spa.model,spa.q,spa.qd,qddDesired,
+  InverseDynamicsConstraints(spa.model,spa.q,spa.qd,qddDesired,
                                           spa.cs, qddIdc,tauIdc);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  }
+  for(unsigned int i=0; i<tauIdc.rows();++i){
+    CHECK_CLOSE(spa.tau[i],tauIdc[i],TEST_PREC);
+  }
+
+
+  InverseDynamicsConstraintsRelaxed(spa.model,spa.q,spa.qd,qddDesired,
+                                    spa.cs, qddIdc,tauIdc);
 
   for(unsigned int i=0; i<qddIdc.rows();++i){
     CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
@@ -211,8 +222,27 @@ TEST(CorrectnessTestWithDoublePerpendicularPendulum){
   //The IDC operator should be able to statisfy qdd=0 and return a tau
   //vector that matches the hand solution produced above.
   dba.cs.SetActuationMap(dba.model,actuationMap);
-  InverseDynamicsConstraintsFullyActuated(dba.model,dba.q,dba.qd,qddDesired,
+  InverseDynamicsConstraints(dba.model,dba.q,dba.qd,qddDesired,
                                           dba.cs, qddIdc,tauIdc);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  }
+  for(unsigned int i=0; i<tauIdc.rows();++i){
+    CHECK_CLOSE(dba.tau[i],tauIdc[i],TEST_PREC);
+  }
+
+  InverseDynamicsConstraintsRelaxed(dba.model,dba.q,dba.qd,qddDesired,
+                                          dba.cs, qddIdc,tauIdc);
+
+  //Check if the result is physically consistent.
+  VectorNd qddCheck(qddIdc.rows());
+  ForwardDynamicsConstraintsDirect(dba.model,dba.q,dba.qd, tauIdc, dba.cs, qddCheck);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(qddCheck[i],qddIdc[i],TEST_PREC);
+  }
+
 
   for(unsigned int i=0; i<qddIdc.rows();++i){
     CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);

--- a/tests/InverseDynamicsWithConstraintsTests.cc
+++ b/tests/InverseDynamicsWithConstraintsTests.cc
@@ -16,247 +16,8 @@ const double TEST_PREC = 1.0e-11;
 const bool flag_printTimingData = false;
 
 
-TEST(CorrectnessTestWithSinglePlanarPendulum){
-
-  //With loop constraints
-  SinglePendulumAbsoluteCoordinates spa
-    = SinglePendulumAbsoluteCoordinates();
-
-  //Without any joint coordinates
-  SinglePendulumJointCoordinates spj
-    = SinglePendulumJointCoordinates();
 
 
-  //1. Set the pendulum modeled using joint coordinates to a specific
-  //    state and then compute the spatial acceleration of the body.
-  spj.q[0]  = M_PI/3.0;   //About z0
-  spj.qd.setZero();
-  spj.qdd.setZero();
-  spj.tau.setZero();
-
-
-  InverseDynamics(spj.model,spj.q,spj.qd,spj.qdd,spj.tau);
-
-  Vector3d r010 = CalcBodyToBaseCoordinates(
-                    spj.model,spj.q,spj.idB1,
-                    Vector3d(0.,0.,0.),true);
-
-  //2. Set the pendulum modelled using absolute coordinates to the
-  //   equivalent state as the pendulum modelled using joint
-  //   coordinates.
-
-  spa.q[0]  = r010[0];
-  spa.q[1]  = r010[1];
-  spa.q[2]  = spj.q[0];
-
-
-  spa.qd.setZero();
-  spa.qdd.setZero();
-
-  spa.tau[0]  = 0.;//tx
-  spa.tau[1]  = 0.;//ty
-  spa.tau[2]  = spj.tau[0];//rz
-
-
-  //Test
-  //  calcPositionError
-  //  calcVelocityError
-
-  VectorNd err(spa.cs.size());
-  VectorNd errd(spa.cs.size());
-
-  CalcConstraintsPositionError(spa.model,spa.q,spa.cs,err,true);
-  CalcConstraintsVelocityError(spa.model,spa.q,spa.qd,spa.cs,errd,true);
-
-  for(unsigned int i=0; i<err.rows();++i){
-    CHECK_CLOSE(0, err[i], TEST_PREC);
-  }
-  for(unsigned int i=0; i<errd.rows();++i){
-    CHECK_CLOSE(0, errd[i], TEST_PREC);
-  }
-
-  ForwardDynamicsConstraintsDirect(spa.model,spa.q, spa.qd, spa.tau,spa.cs,
-                                   spa.qdd);
-  for(unsigned int i=0; i<spa.qdd.rows();++i){
-    CHECK_CLOSE(0., spa.qdd[i], TEST_PREC);
-  }
-
-  std::vector< bool > actuationMap;
-  actuationMap.resize(spa.tau.rows());
-  for(unsigned int i=0; i<actuationMap.size();++i){
-    actuationMap[i]=false;
-  }
-  actuationMap[2] = true;
-
-  VectorNd qddDesired = VectorNd::Zero(spa.qdd.rows());
-  VectorNd qddIdc = VectorNd::Zero(spa.qdd.rows());
-  VectorNd tauIdc = VectorNd::Zero(spa.qdd.rows());
-
-  //The IDC operator should be able to statisfy qdd=0 and return a tau
-  //vector that matches the hand solution produced above.
-  spa.cs.SetActuationMap(spa.model,actuationMap);
-  InverseDynamicsConstraints(spa.model,spa.q,spa.qd,qddDesired,
-                                          spa.cs, qddIdc,tauIdc);
-
-  for(unsigned int i=0; i<qddIdc.rows();++i){
-    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
-  }
-  for(unsigned int i=0; i<tauIdc.rows();++i){
-    CHECK_CLOSE(spa.tau[i],tauIdc[i],TEST_PREC);
-  }
-
-
-  InverseDynamicsConstraintsRelaxed(spa.model,spa.q,spa.qd,qddDesired,
-                                    spa.cs, qddIdc,tauIdc);
-
-  for(unsigned int i=0; i<qddIdc.rows();++i){
-    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
-  }
-  for(unsigned int i=0; i<tauIdc.rows();++i){
-    CHECK_CLOSE(spa.tau[i],tauIdc[i],TEST_PREC);
-  }
-}
-
-
-
-TEST(CorrectnessTestWithDoublePerpendicularPendulum){
-
-  //With loop constraints
-  DoublePerpendicularPendulumAbsoluteCoordinates dba
-    = DoublePerpendicularPendulumAbsoluteCoordinates();
-
-  //Without any joint coordinates
-  DoublePerpendicularPendulumJointCoordinates dbj
-    = DoublePerpendicularPendulumJointCoordinates();
-
-
-  //1. Set the pendulum modeled using joint coordinates to a specific
-  //    state and then compute the spatial acceleration of the body.
-  dbj.q[0]  = M_PI/3.0;   //About z0
-  dbj.q[1]  = M_PI/6.0;         //About y1
-  dbj.qd.setZero();
-  dbj.qdd.setZero();
-  dbj.tau.setZero();
-
-
-  InverseDynamics(dbj.model,dbj.q,dbj.qd,dbj.qdd,dbj.tau);
-  //ForwardDynamics(dbj.model,dbj.q,dbj.qd,dbj.tau,dbj.qdd);
-
-  Vector3d r010 = CalcBodyToBaseCoordinates(
-                    dbj.model,dbj.q,dbj.idB1,
-                    Vector3d(0.,0.,0.),true);
-  Vector3d r020 = CalcBodyToBaseCoordinates(
-                    dbj.model,dbj.q,dbj.idB2,
-                    Vector3d(0.,0.,0.),true);
-  Vector3d r030 = CalcBodyToBaseCoordinates(
-                    dbj.model,dbj.q,dbj.idB2,
-                    Vector3d(dbj.l2,0.,0.),true);
-
-  //2. Set the pendulum modelled using absolute coordinates to the
-  //   equivalent state as the pendulum modelled using joint
-  //   coordinates. Next
-
-
-  dba.q[0]  = r010[0];
-  dba.q[1]  = r010[1];
-  dba.q[2]  = r010[2];
-  dba.q[3]  = dbj.q[0];
-  dba.q[4]  = 0;
-  dba.q[5]  = 0;
-  dba.q[6]  = r020[0];
-  dba.q[7]  = r020[1];
-  dba.q[8]  = r020[2];
-  dba.q[9]  = dbj.q[0];
-  dba.q[10] = dbj.q[1];
-  dba.q[11] = 0;
-
-  dba.qd.setZero();
-  dba.qdd.setZero();
-
-  dba.tau[0]  = 0.;//tx
-  dba.tau[1]  = 0.;//ty
-  dba.tau[2]  = 0.;//tz
-  dba.tau[3]  = dbj.tau[0];//rz
-  dba.tau[4]  = 0.;//ry
-  dba.tau[5]  = 0.;//rx
-  dba.tau[6]  = 0.;//tx
-  dba.tau[7]  = 0.;//ty
-  dba.tau[8]  = 0.;//tz
-  dba.tau[9]  = 0.;//rz
-  dba.tau[10] = dbj.tau[1];//ry
-  dba.tau[11] = 0.;//rx
-
-
-
-  VectorNd err(dba.cs.size());
-  VectorNd errd(dba.cs.size());
-
-  CalcConstraintsPositionError(dba.model,dba.q,dba.cs,err,true);
-  CalcConstraintsVelocityError(dba.model,dba.q,dba.qd,dba.cs,errd,true);
-
-  for(unsigned int i=0; i<err.rows();++i){
-    CHECK_CLOSE(0, err[i], TEST_PREC);
-  }
-  for(unsigned int i=0; i<errd.rows();++i){
-    CHECK_CLOSE(0, errd[i], TEST_PREC);
-  }
-
-  ForwardDynamicsConstraintsDirect(dba.model,dba.q, dba.qd, dba.tau,dba.cs,
-                                   dba.qdd);
-  for(unsigned int i=0; i<dba.qdd.rows();++i){
-    CHECK_CLOSE(0., dba.qdd[i], TEST_PREC);
-  }
-
-  std::vector< bool > actuationMap;
-  actuationMap.resize(dba.tau.rows());
-  for(unsigned int i=0; i<actuationMap.size();++i){
-    actuationMap[i]=false;
-  }
-  actuationMap[3] = true;
-  actuationMap[10] = true;
-
-  VectorNd qddDesired = VectorNd::Zero(dba.qdd.rows());
-  VectorNd qddIdc = VectorNd::Zero(dba.qdd.rows());
-  VectorNd tauIdc = VectorNd::Zero(dba.qdd.rows());
-
-  //The IDC operator should be able to statisfy qdd=0 and return a tau
-  //vector that matches the hand solution produced above.
-  dba.cs.SetActuationMap(dba.model,actuationMap);
-  InverseDynamicsConstraints(dba.model,dba.q,dba.qd,qddDesired,
-                                          dba.cs, qddIdc,tauIdc);
-
-  for(unsigned int i=0; i<qddIdc.rows();++i){
-    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
-  }
-  for(unsigned int i=0; i<tauIdc.rows();++i){
-    CHECK_CLOSE(dba.tau[i],tauIdc[i],TEST_PREC);
-  }
-
-  InverseDynamicsConstraintsRelaxed(dba.model,dba.q,dba.qd,qddDesired,
-                                          dba.cs, qddIdc,tauIdc);
-
-  //Check if the result is physically consistent.
-  VectorNd qddCheck(qddIdc.rows());
-  ForwardDynamicsConstraintsDirect(dba.model,dba.q,dba.qd, tauIdc, dba.cs, qddCheck);
-
-  for(unsigned int i=0; i<qddIdc.rows();++i){
-    CHECK_CLOSE(qddCheck[i],qddIdc[i],TEST_PREC);
-  }
-
-
-  for(unsigned int i=0; i<qddIdc.rows();++i){
-    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
-  }
-  for(unsigned int i=0; i<tauIdc.rows();++i){
-    CHECK_CLOSE(dba.tau[i],tauIdc[i],TEST_PREC);
-  }
-}
-
-
-//M.Millard
-// 24/6/2019
-//These tests were complicated enough that I did not catch a bug
-/*
 void calcCuboidInertia(double mass,
                        double xLength,
                        double yLength,
@@ -560,41 +321,40 @@ TEST_FIXTURE(PlanarBipedFloatingBase, TestCorrectness) {
     }
   }
 
-  //All of the ugly numbers below are pseudo random numbers generated
-  //from Matlab to ensure that the method works, and that the tests are
-  //not passing due to some quirk of symmetry in the state of the model.
+  //A statically stable standing pose
   q0[0] = 0;
   q0[1] = 1.0;
   q0[2] = 0;
-  q0[3] = 5.472155299638031e-01;
-  q0[4] = 1.386244428286791e-01;
-  q0[5] = 1.492940055590575e-01;
-  q0[6] = 2.575082541237365e-01;
+  q0[3] = M_PI*0.25;
+  q0[4] =-M_PI*0.25;
+  q0[5] =-M_PI*0.25;
+  q0[6] = M_PI*0.25;
 
-  qd0[0] = 1.965952504312082e-01;
-  qd0[1] = 2.510838579760311e-01;
-  qd0[2] = 6.160446761466392e-01;
-  qd0[3] = 4.732888489027293e-01;
-  qd0[4] = 3.516595070629968e-01;
-  qd0[5] = 8.308286278962909e-01;
-  qd0[6] = 5.852640911527243e-01;
+  qd0[0] = 0.;
+  qd0[1] = 0.;
+  qd0[2] = 0.;
+  qd0[3] = 0.;
+  qd0[4] = 0.;
+  qd0[5] = 0.;
+  qd0[6] = 0.;
 
   for(unsigned int i =0; i< q.rows();++i){
     weights[i]    = 1;
   }
 
-  qddTarget[0]  = 5.497236082911395e-01;
-  qddTarget[1]  = 9.171936638298100e-01;
-  qddTarget[2]  = 2.858390188203735e-01;
-  qddTarget[3]  = 7.572002291107213e-01;
-  qddTarget[4]  = 7.537290942784953e-01;
-  qddTarget[5]  = 3.804458469753567e-01;
-  qddTarget[6]  = 5.678216407252211e-01;
+  qddTarget[0]  = 0.;
+  qddTarget[1]  = 0.;
+  qddTarget[2]  = 0.;
+  qddTarget[3]  = 0.;
+  qddTarget[4]  = 0.;
+  qddTarget[5]  = 0.;
+  qddTarget[6]  = 0.;
 
 
-  CalcAssemblyQ(model,q0,cs,q,weights);
+  bool qasm = CalcAssemblyQ(model,q0,cs,q,weights);
+  CHECK(qasm);
   CalcAssemblyQDot(model,q,qd0,cs,qd,weights);
-  
+
 
   //6. Call InverseDynamicsConstraints & repeat setps 4 & 5
   VectorNd tauIDC = VectorNd::Zero(tau.size());
@@ -604,6 +364,13 @@ TEST_FIXTURE(PlanarBipedFloatingBase, TestCorrectness) {
   InverseDynamicsConstraints(model,
                              q,qd,qddTarget,
                              cs, qddIDC,tauIDC);
+
+  //In this case the target qdd should be reachable exactly.
+  for(unsigned int i=0; i<qddIDC.rows();++i){
+    CHECK_CLOSE(qddIDC[i], qddTarget[i],TEST_PREC);
+  }
+
+
   lambdaIdc = cs.force;
   ForwardDynamicsConstraintsDirect(model,q,qd,tauIDC,cs,qddFwd);
   lambdaFwd = cs.force;
@@ -618,7 +385,32 @@ TEST_FIXTURE(PlanarBipedFloatingBase, TestCorrectness) {
     CHECK_CLOSE(lambdaIdc[i], lambdaFwd[i], TEST_PREC);
   }
 
-  //Timing comparision    
+  //Check the relaxed method
+  VectorNd tauIDCR(tauIDC.rows());
+  VectorNd qddIDCR(tauIDC.rows());
+  InverseDynamicsConstraintsRelaxed(model,
+                             q,qd,qddTarget,
+                             cs, qddIDCR,tauIDCR);
+  lambdaIdc = cs.force;
+
+  //In this case the acceleration constraint is relaxed and so there
+  //is always some error between what is asked for and what is received.
+  for(unsigned int i=0; i<qddIDC.rows();++i){
+    CHECK_CLOSE(qddIDCR[i], qddTarget[i],0.01);
+  }
+
+  ForwardDynamicsConstraintsDirect(model,q,qd,tauIDCR,cs,qddFwd);
+  lambdaFwd = cs.force;
+
+  lambdaErr=lambdaIdc-lambdaFwd;
+  for(unsigned int i=0; i<q.rows();++i){
+    CHECK_CLOSE(qddIDCR[i], qddFwd[i], TEST_PREC);
+  }
+  for(unsigned int i=0; i<lambdaFwd.rows();++i){
+    CHECK_CLOSE(lambdaIdc[i], lambdaFwd[i], TEST_PREC);
+  }
+
+  //Timing comparision
   if(flag_printTimingData){
     unsigned int iterations = 100;
 
@@ -684,70 +476,71 @@ TEST_FIXTURE(SpatialBipedFloatingBase, TestCorrectness) {
   //from Matlab to ensure that the method works, and that the tests are
   //not passing due to some quirk of symmetry in the state of the model.
 
-  q0[0] = 7.922073295595544e-01;
-  q0[1] = 9.594924263929030e-01;
-  q0[2] = 6.557406991565868e-01;
-  q0[3] = 3.571167857418955e-02;
-  q0[4] = 8.491293058687771e-01;
-  q0[5] = 9.339932477575505e-01;
-  q0[6] = 6.787351548577735e-01;
-  q0[7] = 7.577401305783334e-01;
-  q0[8] = 7.431324681249162e-01;
-  q0[9] = 3.922270195341682e-01;
-  q0[10] = 6.554778901775566e-01;
-  q0[11] = 1.711866878115618e-01;
-  q0[12] = 7.060460880196088e-01;
-  q0[13] = 3.183284637742068e-02;
-  q0[14] = 2.769229849608900e-01;
-  q0[15] = 4.617139063115394e-02;
-  q0[16] = 9.713178123584754e-02;
-  q0[17] = 8.234578283272926e-01;
+  q0[0]  = 0.;         //tx Floating base
+  q0[1]  = 0.;         //ty
+  q0[2]  = 0.75;       //tx
+  q0[3]  = 0.;         //rx
+  q0[4]  = 0.;         //ry
+  q0[5]  = 0.;         //rz
+  q0[6]  = 0.;         //rx Left hip
+  q0[7]  =  M_PI*0.25; //ry
+  q0[8]  = 0.;         //rz
+  q0[9]  = -M_PI*0.25; //ry Left knee
+  q0[10] = 0.;         //rx Left ankle
+  q0[11] = 0.;         //ry
+  q0[12] = 0.;         //rx Right hip
+  q0[13] = -M_PI*0.25; //ry
+  q0[14] = 0.;         //rz
+  q0[15] =  M_PI*0.25; //ry Right knee
+  q0[16] = 0.;         //rx Right ankle
+  q0[17] = 0.;         //ry
 
-
-  qd0[0]  = 6.948286229758170e-01;
-  qd0[1]  = 3.170994800608605e-01;
-  qd0[2]  = 9.502220488383549e-01;
-  qd0[3]  = 3.444608050290876e-02;
-  qd0[4]  = 4.387443596563982e-01;
-  qd0[5]  = 3.815584570930084e-01;
-  qd0[6]  = 7.655167881490024e-01;
-  qd0[7]  = 7.951999011370632e-01;
-  qd0[8]  = 1.868726045543786e-01;
-  qd0[9]  = 4.897643957882311e-01;
-  qd0[10] = 4.455862007108995e-01;
-  qd0[11] = 6.463130101112646e-01;
-  qd0[12] = 7.093648308580726e-01;
-  qd0[13] = 7.546866819823609e-01;
-  qd0[14] = 2.760250769985784e-01;
-  qd0[15] = 6.797026768536748e-01;
-  qd0[16] = 6.550980039738407e-01;
-  qd0[17] = 1.626117351946306e-01;
+  qd0[0]  = 0.;
+  qd0[1]  = 0.;
+  qd0[2]  = 0.;
+  qd0[3]  = 0.;
+  qd0[4]  = 0.;
+  qd0[5]  = 0.;
+  qd0[6]  = 0.;
+  qd0[7]  = 0.;
+  qd0[8]  = 0.;
+  qd0[9]  = 0.;
+  qd0[10] = 0.;
+  qd0[11] = 0.;
+  qd0[12] = 0.;
+  qd0[13] = 0.;
+  qd0[14] = 0.;
+  qd0[15] = 0.;
+  qd0[16] = 0.;
+  qd0[17] = 0.;
 
   for(unsigned int i =0; i< q.rows();++i){
     weights[i]    = 1.;
   }
 
-  qddTarget[0]  = 1.189976815583766e-01;
-  qddTarget[1]  = 4.983640519821430e-01;
-  qddTarget[2]  = 9.597439585160811e-01;
-  qddTarget[3]  = 3.403857266661332e-01;
-  qddTarget[4]  = 5.852677509797773e-01;
-  qddTarget[5]  = 2.238119394911370e-01;
-  qddTarget[6]  = 7.512670593056529e-01;
-  qddTarget[7]  = 2.550951154592691e-01;
-  qddTarget[8]  = 5.059570516651424e-01;
-  qddTarget[9]  = 6.990767226566860e-01;
-  qddTarget[10] = 8.909032525357985e-01;
-  qddTarget[11] = 9.592914252054443e-01;
-  qddTarget[12] = 5.472155299638031e-01;
-  qddTarget[13] = 1.386244428286791e-01;
-  qddTarget[14] = 1.492940055590575e-01;
-  qddTarget[15] = 2.575082541237365e-01;
-  qddTarget[16] = 8.407172559836625e-01;
-  qddTarget[17] = 2.542821789715310e-01;
+  qddTarget[0]  = 0.;
+  qddTarget[1]  = 0.;
+  qddTarget[2]  = 0.;
+  qddTarget[3]  = 0.;
+  qddTarget[4]  = 0.;
+  qddTarget[5]  = 0.;
+  qddTarget[6]  = 0.;
+  qddTarget[7]  = 0.;
+  qddTarget[8]  = 0.;
+  qddTarget[9]  = 0.;
+  qddTarget[10] = 0.;
+  qddTarget[11] = 0.;
+  qddTarget[12] = 0.;
+  qddTarget[13] = 0.;
+  qddTarget[14] = 0.;
+  qddTarget[15] = 0.;
+  qddTarget[16] = 0.;
+  qddTarget[17] = 0.;
 
 
-  CalcAssemblyQ(model,q0,cs,q,weights);
+  bool qAsm=CalcAssemblyQ(model,q0,cs,q,weights);
+  CHECK(qAsm==true);
+
   CalcAssemblyQDot(model,q,qd0,cs,qd,weights);
 
 
@@ -761,9 +554,16 @@ TEST_FIXTURE(SpatialBipedFloatingBase, TestCorrectness) {
                              cs, qddIDC,tauIDC);
   lambdaIdc = cs.force;
 
+  //In this case the target qdd should be reachable exactly.
+  for(unsigned int i=0; i<qddIDC.rows();++i){
+    CHECK_CLOSE(qddIDC[i], qddTarget[i],TEST_PREC);
+  }
+
+
   ForwardDynamicsConstraintsDirect(model,q,qd,tauIDC,cs,qddFwd);
   lambdaFwd = cs.force;
 
+  //Check that the solution is physically consistent
   qddErr = qddIDC-qddFwd;
   lambdaErr= lambdaIdc-lambdaFwd;
   for(unsigned int i=0; i<q.rows();++i){
@@ -772,6 +572,35 @@ TEST_FIXTURE(SpatialBipedFloatingBase, TestCorrectness) {
   for(unsigned int i=0; i<lambdaIdc.rows();++i){
     CHECK_CLOSE(lambdaIdc[i], lambdaFwd[i], TEST_PREC);
   }
+
+  //Check the relaxed method
+  VectorNd tauIDCR(tauIDC.rows());
+  VectorNd qddIDCR(qddIDC.rows());
+  InverseDynamicsConstraintsRelaxed(model,
+                             q,qd,qddTarget,
+                             cs, qddIDCR,tauIDCR);
+  lambdaIdc = cs.force;
+
+  //In this case the acceleration constraint is relaxed and so there
+  //is always some error between what is asked for and what is received.
+  for(unsigned int i=0; i<qddIDCR.rows();++i){
+    CHECK_CLOSE(qddIDCR[i], qddIDC[i],0.01);
+  }
+
+
+  ForwardDynamicsConstraintsDirect(model,q,qd,tauIDCR,cs,qddFwd);
+  lambdaFwd = cs.force;
+
+  //Check that the solution is physically consistent
+  qddErr = qddIDCR-qddFwd;
+  lambdaErr= lambdaIdc-lambdaFwd;
+  for(unsigned int i=0; i<q.rows();++i){
+    CHECK_CLOSE(qddIDC[i], qddFwd[i], TEST_PREC);
+  }
+  for(unsigned int i=0; i<lambdaIdc.rows();++i){
+    CHECK_CLOSE(lambdaIdc[i], lambdaFwd[i], TEST_PREC);
+  }
+
 
   //Timing comparision
   if(flag_printTimingData){
@@ -801,4 +630,246 @@ TEST_FIXTURE(SpatialBipedFloatingBase, TestCorrectness) {
                         << double(tfd.count())/double(tfd.count()) << std::endl;
   }
 }
-*/
+
+
+TEST(CorrectnessTestWithSinglePlanarPendulum){
+
+  //With loop constraints
+  SinglePendulumAbsoluteCoordinates spa
+    = SinglePendulumAbsoluteCoordinates();
+
+  //Without any joint coordinates
+  SinglePendulumJointCoordinates spj
+    = SinglePendulumJointCoordinates();
+
+
+  //1. Set the pendulum modeled using joint coordinates to a specific
+  //    state and then compute the spatial acceleration of the body.
+  spj.q[0]  = M_PI/3.0;   //About z0
+  spj.qd.setZero();
+  spj.qdd.setZero();
+  spj.tau.setZero();
+
+
+  InverseDynamics(spj.model,spj.q,spj.qd,spj.qdd,spj.tau);
+
+  Vector3d r010 = CalcBodyToBaseCoordinates(
+                    spj.model,spj.q,spj.idB1,
+                    Vector3d(0.,0.,0.),true);
+
+  //2. Set the pendulum modelled using absolute coordinates to the
+  //   equivalent state as the pendulum modelled using joint
+  //   coordinates.
+
+  spa.q[0]  = r010[0];
+  spa.q[1]  = r010[1];
+  spa.q[2]  = spj.q[0];
+
+
+  spa.qd.setZero();
+  spa.qdd.setZero();
+
+  spa.tau[0]  = 0.;//tx
+  spa.tau[1]  = 0.;//ty
+  spa.tau[2]  = spj.tau[0];//rz
+
+
+  //Test
+  //  calcPositionError
+  //  calcVelocityError
+
+  VectorNd err(spa.cs.size());
+  VectorNd errd(spa.cs.size());
+
+  CalcConstraintsPositionError(spa.model,spa.q,spa.cs,err,true);
+  CalcConstraintsVelocityError(spa.model,spa.q,spa.qd,spa.cs,errd,true);
+
+  for(unsigned int i=0; i<err.rows();++i){
+    CHECK_CLOSE(0, err[i], TEST_PREC);
+  }
+  for(unsigned int i=0; i<errd.rows();++i){
+    CHECK_CLOSE(0, errd[i], TEST_PREC);
+  }
+
+  ForwardDynamicsConstraintsDirect(spa.model,spa.q, spa.qd, spa.tau,spa.cs,
+                                   spa.qdd);
+  for(unsigned int i=0; i<spa.qdd.rows();++i){
+    CHECK_CLOSE(0., spa.qdd[i], TEST_PREC);
+  }
+
+  std::vector< bool > actuationMap;
+  actuationMap.resize(spa.tau.rows());
+  for(unsigned int i=0; i<actuationMap.size();++i){
+    actuationMap[i]=false;
+  }
+  actuationMap[2] = true;
+
+  VectorNd qddDesired = VectorNd::Zero(spa.qdd.rows());
+  VectorNd qddIdc = VectorNd::Zero(spa.qdd.rows());
+  VectorNd tauIdc = VectorNd::Zero(spa.qdd.rows());
+
+  //The IDC operator should be able to statisfy qdd=0 and return a tau
+  //vector that matches the hand solution produced above.
+  spa.cs.SetActuationMap(spa.model,actuationMap);
+  InverseDynamicsConstraints(spa.model,spa.q,spa.qd,qddDesired,
+                                          spa.cs, qddIdc,tauIdc);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  }
+  for(unsigned int i=0; i<tauIdc.rows();++i){
+    CHECK_CLOSE(spa.tau[i],tauIdc[i],TEST_PREC);
+  }
+
+
+  InverseDynamicsConstraintsRelaxed(spa.model,spa.q,spa.qd,qddDesired,
+                                    spa.cs, qddIdc,tauIdc);
+
+  //For this simple system with only point-ground constraints the
+  //desired qdd's should be met exactly (thanks to the small updates I've made
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  }
+  for(unsigned int i=0; i<tauIdc.rows();++i){
+    CHECK_CLOSE(spa.tau[i],tauIdc[i],TEST_PREC);
+  }
+}
+
+
+
+TEST(CorrectnessTestWithDoublePerpendicularPendulum){
+
+  //With loop constraints
+  DoublePerpendicularPendulumAbsoluteCoordinates dba
+    = DoublePerpendicularPendulumAbsoluteCoordinates();
+
+  //Without any joint coordinates
+  DoublePerpendicularPendulumJointCoordinates dbj
+    = DoublePerpendicularPendulumJointCoordinates();
+
+
+  //1. Set the pendulum modeled using joint coordinates to a specific
+  //    state and then compute the spatial acceleration of the body.
+  dbj.q[0]  = M_PI/3.0;   //About z0
+  dbj.q[1]  = M_PI/6.0;         //About y1
+  dbj.qd.setZero();
+  dbj.qdd.setZero();
+  dbj.tau.setZero();
+
+
+  InverseDynamics(dbj.model,dbj.q,dbj.qd,dbj.qdd,dbj.tau);
+  //ForwardDynamics(dbj.model,dbj.q,dbj.qd,dbj.tau,dbj.qdd);
+
+  Vector3d r010 = CalcBodyToBaseCoordinates(
+                    dbj.model,dbj.q,dbj.idB1,
+                    Vector3d(0.,0.,0.),true);
+  Vector3d r020 = CalcBodyToBaseCoordinates(
+                    dbj.model,dbj.q,dbj.idB2,
+                    Vector3d(0.,0.,0.),true);
+  Vector3d r030 = CalcBodyToBaseCoordinates(
+                    dbj.model,dbj.q,dbj.idB2,
+                    Vector3d(dbj.l2,0.,0.),true);
+
+  //2. Set the pendulum modelled using absolute coordinates to the
+  //   equivalent state as the pendulum modelled using joint
+  //   coordinates. Next
+
+
+  dba.q[0]  = r010[0];
+  dba.q[1]  = r010[1];
+  dba.q[2]  = r010[2];
+  dba.q[3]  = dbj.q[0];
+  dba.q[4]  = 0;
+  dba.q[5]  = 0;
+  dba.q[6]  = r020[0];
+  dba.q[7]  = r020[1];
+  dba.q[8]  = r020[2];
+  dba.q[9]  = dbj.q[0];
+  dba.q[10] = dbj.q[1];
+  dba.q[11] = 0;
+
+  dba.qd.setZero();
+  dba.qdd.setZero();
+
+  dba.tau[0]  = 0.;//tx
+  dba.tau[1]  = 0.;//ty
+  dba.tau[2]  = 0.;//tz
+  dba.tau[3]  = dbj.tau[0];//rz
+  dba.tau[4]  = 0.;//ry
+  dba.tau[5]  = 0.;//rx
+  dba.tau[6]  = 0.;//tx
+  dba.tau[7]  = 0.;//ty
+  dba.tau[8]  = 0.;//tz
+  dba.tau[9]  = 0.;//rz
+  dba.tau[10] = dbj.tau[1];//ry
+  dba.tau[11] = 0.;//rx
+
+
+
+  VectorNd err(dba.cs.size());
+  VectorNd errd(dba.cs.size());
+
+  CalcConstraintsPositionError(dba.model,dba.q,dba.cs,err,true);
+  CalcConstraintsVelocityError(dba.model,dba.q,dba.qd,dba.cs,errd,true);
+
+  for(unsigned int i=0; i<err.rows();++i){
+    CHECK_CLOSE(0, err[i], TEST_PREC);
+  }
+  for(unsigned int i=0; i<errd.rows();++i){
+    CHECK_CLOSE(0, errd[i], TEST_PREC);
+  }
+
+  ForwardDynamicsConstraintsDirect(dba.model,dba.q, dba.qd, dba.tau,dba.cs,
+                                   dba.qdd);
+  for(unsigned int i=0; i<dba.qdd.rows();++i){
+    CHECK_CLOSE(0., dba.qdd[i], TEST_PREC);
+  }
+
+  std::vector< bool > actuationMap;
+  actuationMap.resize(dba.tau.rows());
+  for(unsigned int i=0; i<actuationMap.size();++i){
+    actuationMap[i]=false;
+  }
+  actuationMap[3] = true;
+  actuationMap[10] = true;
+
+  VectorNd qddDesired = VectorNd::Zero(dba.qdd.rows());
+  VectorNd qddIdc = VectorNd::Zero(dba.qdd.rows());
+  VectorNd tauIdc = VectorNd::Zero(dba.qdd.rows());
+
+  //The IDC operator should be able to statisfy qdd=0 and return a tau
+  //vector that matches the hand solution produced above.
+  dba.cs.SetActuationMap(dba.model,actuationMap);
+  InverseDynamicsConstraints(dba.model,dba.q,dba.qd,qddDesired,
+                                          dba.cs, qddIdc,tauIdc);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  }
+  for(unsigned int i=0; i<tauIdc.rows();++i){
+    CHECK_CLOSE(dba.tau[i],tauIdc[i],TEST_PREC);
+  }
+
+  InverseDynamicsConstraintsRelaxed(dba.model,dba.q,dba.qd,qddDesired,
+                                          dba.cs, qddIdc,tauIdc);
+
+  //Check if the result is physically consistent.
+  VectorNd qddCheck(qddIdc.rows());
+  ForwardDynamicsConstraintsDirect(dba.model,dba.q,dba.qd, tauIdc, dba.cs, qddCheck);
+
+  for(unsigned int i=0; i<qddIdc.rows();++i){
+    CHECK_CLOSE(qddCheck[i],qddIdc[i],TEST_PREC);
+  }
+
+  //Unfortunately because this system contains loop constraints the
+  //IDC relaxed operator is not able to exactly satisfy the desired accelerations
+
+  //for(unsigned int i=0; i<qddIdc.rows();++i){
+  //  CHECK_CLOSE(0.,qddIdc[i],TEST_PREC);
+  //}
+  //for(unsigned int i=0; i<tauIdc.rows();++i){
+  //  CHECK_CLOSE(dba.tau[i],tauIdc[i],TEST_PREC);
+  //}
+}
+
+

--- a/tests/PendulumModels.h
+++ b/tests/PendulumModels.h
@@ -181,3 +181,133 @@ struct DoublePerpendicularPendulumAbsoluteCoordinates {
   RigidBodyDynamics::Math::SpatialTransform X_p2;
   RigidBodyDynamics::Math::SpatialTransform X_s2;
 };
+
+//==============================================================================
+struct SinglePendulumJointCoordinates {
+  SinglePendulumJointCoordinates()
+    : model()
+    , q()
+    , qd()
+    , qdd()
+    , tau()
+    , l1(1.)
+    , m1(1.)
+    , idB1(0){
+    using namespace RigidBodyDynamics;
+    using namespace RigidBodyDynamics::Math;
+
+    model.gravity = Vector3d(0.,-9.81,0.);
+    /*
+      The perpendicular pendulum pictured with joint angles of 0,0.
+      The first joint rotates about the x axis, while the second
+      joint rotates about the local y axis of link 1
+
+         y
+         |
+         |___ x
+      z / |
+        | |
+      / | | link1
+        | |
+    /   | |
+        | |
+        +-+
+    */
+
+    Body link1 = Body(m1, Vector3d(          0., -l1*0.5,          0.),
+                      Matrix3d( m1*l1*l1/3.,           0.,           0.,
+                                         0., m1*l1*l1/30.,           0.,
+                                         0.,           0.,  m1*l1*l1/3.));
+
+
+
+    Joint joint_rev_z = Joint(SpatialVector(0.,0.,1.,0.,0.,0.));
+
+    idB1 = model.AddBody(   0, Xtrans(Vector3d(0., 0, 0. )),
+                            joint_rev_z, link1, "body1");
+
+    q   = VectorNd::Zero(model.dof_count);
+    qd  = VectorNd::Zero(model.dof_count);
+    qdd = VectorNd::Zero(model.dof_count);
+    tau = VectorNd::Zero(model.dof_count);
+  }
+
+  RigidBodyDynamics::Model model;
+
+  RigidBodyDynamics::Math::VectorNd q;
+  RigidBodyDynamics::Math::VectorNd qd;
+  RigidBodyDynamics::Math::VectorNd qdd;
+  RigidBodyDynamics::Math::VectorNd tau;
+
+  double l1;
+  double m1;
+
+  unsigned int idB1;
+};
+
+struct SinglePendulumAbsoluteCoordinates {
+  SinglePendulumAbsoluteCoordinates()
+    : model()
+    , cs()
+    , q()
+    , qd()
+    , qdd()
+    , tau()
+    , l1(1.)
+    , m1(1.)
+    , idB1(0)
+    , X_p1(RigidBodyDynamics::Math::Xtrans(
+            RigidBodyDynamics::Math::Vector3d(0., 0., 0.)))
+    , X_s1(RigidBodyDynamics::Math::Xtrans(
+            RigidBodyDynamics::Math::Vector3d(0., 0., 0.))){
+
+    using namespace RigidBodyDynamics;
+    using namespace RigidBodyDynamics::Math;
+
+    model.gravity = Vector3d(0.,-9.81,0.);
+    //Planar pendulum is at 0 when it is hanging down.
+    //  x: points to the right
+    //  y: points up
+    //  z: out of the page
+    Body link1 = Body(m1, Vector3d(          0., -l1*0.5,          0.),
+                      Matrix3d( m1*l1*l1/3.,          0. ,           0.,
+                                         0., m1*l1*l1/30.,           0.,
+                                         0.,          0. ,  m1*l1*l1/3.));
+
+    Joint jointXYRz (SpatialVector(0.,0.,0., 1.,0.,0.),
+                     SpatialVector(0.,0.,0., 0.,1.,0.),
+                     SpatialVector(0.,0.,1., 0.,0.,0.));
+
+    idB1 = model.AddBody(0, SpatialTransform(), jointXYRz, link1);
+
+    //Make the revolute joints about the y axis using 5 constraints
+    //between the end points
+    cpX = cs.AddContactConstraint(idB1,Vector3dZero,Vector3d(1.,0.,0.),"cx");
+    cpY = cs.AddContactConstraint(idB1,Vector3dZero,Vector3d(0.,1.,0.),"cy");
+
+    cs.Bind(model);
+
+    q   = VectorNd::Zero(model.dof_count);
+    qd  = VectorNd::Zero(model.dof_count);
+    qdd = VectorNd::Zero(model.dof_count);
+    tau = VectorNd::Zero(model.dof_count);
+  }
+
+
+  RigidBodyDynamics::Model model;
+  RigidBodyDynamics::ConstraintSet cs;
+
+  RigidBodyDynamics::Math::VectorNd q;
+  RigidBodyDynamics::Math::VectorNd qd;
+  RigidBodyDynamics::Math::VectorNd qdd;
+  RigidBodyDynamics::Math::VectorNd tau;
+
+  double l1;
+  double m1;
+
+  unsigned int idB1;
+  unsigned int cpX,cpY;
+
+  RigidBodyDynamics::Math::SpatialTransform X_p1;
+  RigidBodyDynamics::Math::SpatialTransform X_s1;
+};


### PR DESCRIPTION
This pull request is in response to an issue that a user of RBDL was having. In summary here is what has been done:

------------------------------
Code:
1. InverseDynamicsConstraints: An exact method from Eqn. 5.20 of Henning's thesis has been implemented which can only be applied to fully actuated constrained systems. I have added this method as it is useful and it is what most people were expecting given the name.

2. isConstrainedSystemFullyActuated: a method that can be used to test if a constrained system is fully actuated.

3. InverseDynamicsConstraintsRelaxed: The inverse-dynamics-with-constraints operator but with relaxed accelerations. The null space method described in section 2.5 of Henning's thesis is implemented. I have made a few modifications so that the final solution is closer to the desired accelerations (qdd*):
3a. Internally the desired acceleration vector is modified so that it perfectly compensates the projection of gravitational and non-linear terms: the SN term gets cancelled.
3b. The weighting matrix is set to be a large diagonal matrix (relative to the mass matrix) so that the final solution for qdd is close to S qdd*.

------------------------------

Doxygen:
4. All of the existing and new methods have had a good doxygen overhaul.

------------------------------

Test-code:
5. The bugs that bzroom (Bitbucket id) found in the test code have been fixed on following tests:
  TEST_FIXTURE(PlanarBipedFloatingBase, TestCorrectness)
  TEST_FIXTURE(SpatialBipedFloatingBase, TestCorrectness)

  Result:
  -When fully actuated both of these models will exactly satisfy qdd* with InverseDynamicsConstraints, but will only come close to desired value using InverseDynamicsConstraintsRelaxed (as is expected)
  -When under actuated (tested only with the planar model) the InverseDynamicsConstraintsRelaxed method comes close to satisfying the desired accelerations that are controlled.

6. There is now test code that includes hand calculations (or the close to them) using a single and double pendulums:

CorrectnessTestWithSinglePlanarPendulum
CorrectnessTestWithDoublePerpendicularPendulum

Again all checks out:
 InverseDynamicsConstraints returns the exact values
 InverseDynamicsConstraintsRelaxed returns values for qdd close to qdd* that are physically consistent

7. The under actuated cart-pendulum that appears in Henning's thesis is also now a test case for InverseDynamicsConstraintsRelaxed

CorrectnessTestWithUnderactuatedCartPendulum

------------------------------

8. Both InverseDynamicsConstraints and InverseDynamicsConstraintsRelaxed exploit the triangular structure of the KKT system. As a result InverseDynamicsConstraints is around 10-20% faster than ForwardDynamicsConstraintsNullSpace and InverseDynamicsConstraintsRelaxed is around 10-40% percent flower than ForwardDynamicsConstraintsNullSpace.

9. I cannot get InverseDynamicsConstraints to work with SimpleMath. I have used if-defs to seletively build it. The implementation of InverseDynamicsConstraints contains a comment on the line that fails with SimpleMath. I think its failing because SimpleMath doesn't play nice with non-square matrices A when solving Ax=b.