### PR TITLE
Fixed urdfreader boost typedef issues

### DIFF
--- a/addons/urdfreader/urdfreader.cc
+++ b/addons/urdfreader/urdfreader.cc
@@ -9,22 +9,23 @@
 #include <stack>
 
 #ifdef RBDL_USE_ROS_URDF_LIBRARY
-  #include <urdf_model/model.h>
-  #include <urdf_parser/urdf_parser.h>
+#include <urdf_model/model.h>
+#include <urdf_parser/urdf_parser.h>
+#include <boost/shared_ptr.hpp>
 
-  typedef boost::shared_ptr<urdf::Link> LinkPtr;
-  typedef const boost::shared_ptr<const urdf::Link> ConstLinkPtr;
-  typedef boost::shared_ptr<urdf::Joint> JointPtr;
-  typedef boost::shared_ptr<urdf::ModelInterface> ModelPtr;
+typedef urdf::LinkSharedPtr LinkPtr;
+typedef const urdf::LinkConstSharedPtr ConstLinkPtr;
+typedef urdf::JointSharedPtr JointPtr;
+typedef urdf::ModelInterfaceSharedPtr ModelPtr;
 
 #else
-  #include <urdf/urdfdom_headers/urdf_model/include/urdf_model/model.h>
-  #include <urdf/urdfdom/urdf_parser/include/urdf_parser/urdf_parser.h>
+#include <urdf/urdfdom_headers/urdf_model/include/urdf_model/model.h>
+#include <urdf/urdfdom/urdf_parser/include/urdf_parser/urdf_parser.h>
 
-  typedef my_shared_ptr<urdf::Link> LinkPtr;
-  typedef const my_shared_ptr<const urdf::Link> ConstLinkPtr;
-  typedef my_shared_ptr<urdf::Joint> JointPtr;
-  typedef my_shared_ptr<urdf::ModelInterface> ModelPtr;
+typedef my_shared_ptr<urdf::Link> LinkPtr;
+typedef const my_shared_ptr<const urdf::Link> ConstLinkPtr;
+typedef my_shared_ptr<urdf::Joint> JointPtr;
+typedef my_shared_ptr<urdf::ModelInterface> ModelPtr;
 
 #endif
 
@@ -40,11 +41,10 @@ using namespace Math;
 
 typedef vector<LinkPtr> URDFLinkVector;
 typedef vector<JointPtr> URDFJointVector;
-typedef map<string, LinkPtr > URDFLinkMap;
-typedef map<string, JointPtr > URDFJointMap;
+typedef map<string, LinkPtr> URDFLinkMap;
+typedef map<string, JointPtr> URDFJointMap;
 
-bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
-                      bool floating_base, bool verbose)
+bool construct_model(Model *rbdl_model, ModelPtr urdf_model, bool floating_base, bool verbose)
 {
   LinkPtr urdf_root_link;
 
@@ -57,63 +57,69 @@ bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
   vector<string> joint_names;
 
   // Holds the links that we are processing in our depth first traversal with the top element being the current link.
-  stack<LinkPtr > link_stack;
+  stack<LinkPtr> link_stack;
   // Holds the child joint index of the current link
   stack<int> joint_index_stack;
 
   // add the bodies in a depth-first order of the model tree
-  link_stack.push (link_map[(urdf_model->getRoot()->name)]);
+  link_stack.push(link_map[(urdf_model->getRoot()->name)]);
 
   // add the root body
-  ConstLinkPtr& root = urdf_model->getRoot ();
+  ConstLinkPtr &root = urdf_model->getRoot();
   Vector3d root_inertial_rpy;
   Vector3d root_inertial_position;
   Matrix3d root_inertial_inertia;
   double root_inertial_mass;
 
-  if (root->inertial) {
+  if (root->inertial)
+  {
     root_inertial_mass = root->inertial->mass;
 
-    root_inertial_position.set (
-      root->inertial->origin.position.x,
-      root->inertial->origin.position.y,
-      root->inertial->origin.position.z);
+    root_inertial_position.set(
+        root->inertial->origin.position.x,
+        root->inertial->origin.position.y,
+        root->inertial->origin.position.z);
 
-    root_inertial_inertia(0,0) = root->inertial->ixx;
-    root_inertial_inertia(0,1) = root->inertial->ixy;
-    root_inertial_inertia(0,2) = root->inertial->ixz;
+    root_inertial_inertia(0, 0) = root->inertial->ixx;
+    root_inertial_inertia(0, 1) = root->inertial->ixy;
+    root_inertial_inertia(0, 2) = root->inertial->ixz;
 
-    root_inertial_inertia(1,0) = root->inertial->ixy;
-    root_inertial_inertia(1,1) = root->inertial->iyy;
-    root_inertial_inertia(1,2) = root->inertial->iyz;
+    root_inertial_inertia(1, 0) = root->inertial->ixy;
+    root_inertial_inertia(1, 1) = root->inertial->iyy;
+    root_inertial_inertia(1, 2) = root->inertial->iyz;
 
-    root_inertial_inertia(2,0) = root->inertial->ixz;
-    root_inertial_inertia(2,1) = root->inertial->iyz;
-    root_inertial_inertia(2,2) = root->inertial->izz;
+    root_inertial_inertia(2, 0) = root->inertial->ixz;
+    root_inertial_inertia(2, 1) = root->inertial->iyz;
+    root_inertial_inertia(2, 2) = root->inertial->izz;
 
-    root->inertial->origin.rotation.getRPY (root_inertial_rpy[0],
-                                            root_inertial_rpy[1], root_inertial_rpy[2]);
+    root->inertial->origin.rotation.getRPY(root_inertial_rpy[0], root_inertial_rpy[1], root_inertial_rpy[2]);
 
-    Body root_link = Body (root_inertial_mass,
-                           root_inertial_position,
-                           root_inertial_inertia);
+    Body root_link = Body(root_inertial_mass,
+                          root_inertial_position,
+                          root_inertial_inertia);
 
-    Joint root_joint (JointTypeFixed);
-    if (floating_base) {
+    Joint root_joint(JointTypeFixed);
+    if (floating_base)
+    {
       root_joint = JointTypeFloatingBase;
     }
 
-    SpatialTransform root_joint_frame = SpatialTransform ();
+    SpatialTransform root_joint_frame = SpatialTransform();
 
-    if (verbose) {
+    if (verbose)
+    {
       cout << "+ Adding Root Body " << endl;
       cout << "  joint frame: " << root_joint_frame << endl;
-      if (floating_base) {
+      if (floating_base)
+      {
         cout << "  joint type : floating" << endl;
-      } else {
+      }
+      else
+      {
         cout << "  joint type : fixed" << endl;
       }
-      cout << "  body inertia: " << endl << root_link.mInertia << endl;
+      cout << "  body inertia: " << endl
+           << root_link.mInertia << endl;
       cout << "  body mass   : " << root_link.mMass << endl;
       cout << "  body name   : " << root->name << endl;
     }
@@ -127,39 +133,45 @@ bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
   // depth first traversal: push the first child onto our joint_index_stack
   joint_index_stack.push(0);
 
-  while (link_stack.size() > 0) {
+  while (link_stack.size() > 0)
+  {
     LinkPtr cur_link = link_stack.top();
 
     unsigned int joint_idx = joint_index_stack.top();
 
     // Add any child bodies and increment current joint index if we still have child joints to process.
-    if (joint_idx < cur_link->child_joints.size()) {
+    if (joint_idx < cur_link->child_joints.size())
+    {
       JointPtr cur_joint = cur_link->child_joints[joint_idx];
 
       // increment joint index
       joint_index_stack.pop();
-      joint_index_stack.push (joint_idx + 1);
+      joint_index_stack.push(joint_idx + 1);
 
-      link_stack.push (link_map[cur_joint->child_link_name]);
+      link_stack.push(link_map[cur_joint->child_link_name]);
       joint_index_stack.push(0);
 
-      if (verbose) {
-        for (unsigned int i = 1; i < joint_index_stack.size() - 1; i++) {
+      if (verbose)
+      {
+        for (unsigned int i = 1; i < joint_index_stack.size() - 1; i++)
+        {
           cout << "  ";
         }
-        cout << "joint '" << cur_joint->name << "' child link '" <<
-             link_stack.top()->name << "' type = " << cur_joint->type << endl;
+        cout << "joint '" << cur_joint->name << "' child link '" << link_stack.top()->name << "' type = " << cur_joint->type << endl;
       }
 
       joint_names.push_back(cur_joint->name);
-    } else {
+    }
+    else
+    {
       link_stack.pop();
       joint_index_stack.pop();
     }
   }
 
   unsigned int j;
-  for (j = 0; j < joint_names.size(); j++) {
+  for (j = 0; j < joint_names.size(); j++)
+  {
     JointPtr urdf_joint = joint_map[joint_names[j]];
     LinkPtr urdf_parent = link_map[urdf_joint->parent_link_name];
     LinkPtr urdf_child = link_map[urdf_joint->child_link_name];
@@ -167,10 +179,9 @@ bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
     // determine where to add the current joint and child body
     unsigned int rbdl_parent_id = 0;
 
-    // Resolve names of global reference frame parents
-    if (urdf_parent->name != "base_link"
-        && urdf_parent->name != "world") {
-      rbdl_parent_id = rbdl_model->GetBodyId (urdf_parent->name.c_str());
+    if (urdf_parent->name != "base_link")
+    {
+      rbdl_parent_id = rbdl_model->GetBodyId(urdf_parent->name.c_str());
     }
 
     if (rbdl_parent_id == std::numeric_limits<unsigned int>::max())
@@ -182,49 +193,47 @@ bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
 
     // create the joint
     Joint rbdl_joint;
-    if (urdf_joint->type == urdf::Joint::REVOLUTE ||
-        urdf_joint->type == urdf::Joint::CONTINUOUS) {
-      rbdl_joint = Joint (SpatialVector (urdf_joint->axis.x, urdf_joint->axis.y,
-                                         urdf_joint->axis.z, 0., 0., 0.));
-    } else if (urdf_joint->type == urdf::Joint::PRISMATIC) {
-      rbdl_joint = Joint (SpatialVector (0., 0., 0., urdf_joint->axis.x,
-                                         urdf_joint->axis.y, urdf_joint->axis.z));
-    } else if (urdf_joint->type == urdf::Joint::FIXED) {
-      rbdl_joint = Joint (JointTypeFixed);
-    } else if (urdf_joint->type == urdf::Joint::FLOATING) {
+    if (urdf_joint->type == urdf::Joint::REVOLUTE || urdf_joint->type == urdf::Joint::CONTINUOUS)
+    {
+      rbdl_joint = Joint(SpatialVector(urdf_joint->axis.x, urdf_joint->axis.y, urdf_joint->axis.z, 0., 0., 0.));
+    }
+    else if (urdf_joint->type == urdf::Joint::PRISMATIC)
+    {
+      rbdl_joint = Joint(SpatialVector(0., 0., 0., urdf_joint->axis.x, urdf_joint->axis.y, urdf_joint->axis.z));
+    }
+    else if (urdf_joint->type == urdf::Joint::FIXED)
+    {
+      rbdl_joint = Joint(JointTypeFixed);
+    }
+    else if (urdf_joint->type == urdf::Joint::FLOATING)
+    {
       // todo: what order of DoF should be used?
-      rbdl_joint = Joint (
-                     SpatialVector (0., 0., 0., 1., 0., 0.),
-                     SpatialVector (0., 0., 0., 0., 1., 0.),
-                     SpatialVector (0., 0., 0., 0., 0., 1.),
-                     SpatialVector (1., 0., 0., 0., 0., 0.),
-                     SpatialVector (0., 1., 0., 0., 0., 0.),
-                     SpatialVector (0., 0., 1., 0., 0., 0.));
-    } else if (urdf_joint->type == urdf::Joint::PLANAR) {
+      rbdl_joint = Joint(
+          SpatialVector(0., 0., 0., 1., 0., 0.),
+          SpatialVector(0., 0., 0., 0., 1., 0.),
+          SpatialVector(0., 0., 0., 0., 0., 1.),
+          SpatialVector(1., 0., 0., 0., 0., 0.),
+          SpatialVector(0., 1., 0., 0., 0., 0.),
+          SpatialVector(0., 0., 1., 0., 0., 0.));
+    }
+    else if (urdf_joint->type == urdf::Joint::PLANAR)
+    {
       // todo: which two directions should be used that are perpendicular
       // to the specified axis?
-      cerr << "Error while processing joint '" << urdf_joint->name <<
-           "': planar joints not yet supported!" << endl;
+      cerr << "Error while processing joint '" << urdf_joint->name << "': planar joints not yet supported!" << endl;
       return false;
     }
 
     // compute the joint transformation
     Vector3d joint_rpy;
     Vector3d joint_translation;
-    urdf_joint->parent_to_joint_origin_transform.rotation.getRPY (joint_rpy[0],
-        joint_rpy[1], joint_rpy[2]);
-    joint_translation.set (
-      urdf_joint->parent_to_joint_origin_transform.position.x,
-      urdf_joint->parent_to_joint_origin_transform.position.y,
-      urdf_joint->parent_to_joint_origin_transform.position.z
-    );
+    urdf_joint->parent_to_joint_origin_transform.rotation.getRPY(joint_rpy[0], joint_rpy[1], joint_rpy[2]);
+    joint_translation.set(
+        urdf_joint->parent_to_joint_origin_transform.position.x,
+        urdf_joint->parent_to_joint_origin_transform.position.y,
+        urdf_joint->parent_to_joint_origin_transform.position.z);
     SpatialTransform rbdl_joint_frame =
-      Xrot (joint_rpy[0], Vector3d (1., 0., 0.))
-      * Xrot (joint_rpy[1], Vector3d (0., 1., 0.))
-      * Xrot (joint_rpy[2], Vector3d (0., 0., 1.))
-      * Xtrans (Vector3d (
-                  joint_translation
-                ));
+        Xrot(joint_rpy[0], Vector3d(1., 0., 0.)) * Xrot(joint_rpy[1], Vector3d(0., 1., 0.)) * Xrot(joint_rpy[2], Vector3d(0., 0., 1.)) * Xtrans(Vector3d(joint_translation));
 
     // assemble the body
     Vector3d link_inertial_position;
@@ -233,116 +242,112 @@ bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
     double link_inertial_mass = 0.;
 
     // but only if we actually have inertial data
-    if (urdf_child->inertial) {
+    if (urdf_child->inertial)
+    {
       link_inertial_mass = urdf_child->inertial->mass;
 
-      link_inertial_position.set (
-        urdf_child->inertial->origin.position.x,
-        urdf_child->inertial->origin.position.y,
-        urdf_child->inertial->origin.position.z
-      );
-      urdf_child->inertial->origin.rotation.getRPY (link_inertial_rpy[0],
-          link_inertial_rpy[1], link_inertial_rpy[2]);
+      link_inertial_position.set(
+          urdf_child->inertial->origin.position.x,
+          urdf_child->inertial->origin.position.y,
+          urdf_child->inertial->origin.position.z);
+      urdf_child->inertial->origin.rotation.getRPY(link_inertial_rpy[0], link_inertial_rpy[1], link_inertial_rpy[2]);
 
-      link_inertial_inertia(0,0) = urdf_child->inertial->ixx;
-      link_inertial_inertia(0,1) = urdf_child->inertial->ixy;
-      link_inertial_inertia(0,2) = urdf_child->inertial->ixz;
+      link_inertial_inertia(0, 0) = urdf_child->inertial->ixx;
+      link_inertial_inertia(0, 1) = urdf_child->inertial->ixy;
+      link_inertial_inertia(0, 2) = urdf_child->inertial->ixz;
 
-      link_inertial_inertia(1,0) = urdf_child->inertial->ixy;
-      link_inertial_inertia(1,1) = urdf_child->inertial->iyy;
-      link_inertial_inertia(1,2) = urdf_child->inertial->iyz;
+      link_inertial_inertia(1, 0) = urdf_child->inertial->ixy;
+      link_inertial_inertia(1, 1) = urdf_child->inertial->iyy;
+      link_inertial_inertia(1, 2) = urdf_child->inertial->iyz;
 
-      link_inertial_inertia(2,0) = urdf_child->inertial->ixz;
-      link_inertial_inertia(2,1) = urdf_child->inertial->iyz;
-      link_inertial_inertia(2,2) = urdf_child->inertial->izz;
+      link_inertial_inertia(2, 0) = urdf_child->inertial->ixz;
+      link_inertial_inertia(2, 1) = urdf_child->inertial->iyz;
+      link_inertial_inertia(2, 2) = urdf_child->inertial->izz;
 
-      if (link_inertial_rpy != Vector3d (0., 0., 0.)) {
-        cerr << "Error while processing body '" << urdf_child->name <<
-             "': rotation of body frames not yet supported. Please rotate the joint frame instead."
-             << endl;
+      if (link_inertial_rpy != Vector3d(0., 0., 0.))
+      {
+        cerr << "Error while processing body '" << urdf_child->name << "': rotation of body frames not yet supported. Please rotate the joint frame instead." << endl;
         return false;
       }
     }
 
-    Body rbdl_body = Body (link_inertial_mass, link_inertial_position,
-                           link_inertial_inertia);
+    Body rbdl_body = Body(link_inertial_mass, link_inertial_position, link_inertial_inertia);
 
-    if (verbose) {
+    if (verbose)
+    {
       cout << "+ Adding Body: " << urdf_child->name << endl;
       cout << "  parent_id  : " << rbdl_parent_id << endl;
       cout << "  joint frame: " << rbdl_joint_frame << endl;
       cout << "  joint dofs : " << rbdl_joint.mDoFCount << endl;
-      for (unsigned int j = 0; j < rbdl_joint.mDoFCount; j++) {
+      for (unsigned int j = 0; j < rbdl_joint.mDoFCount; j++)
+      {
         cout << "    " << j << ": " << rbdl_joint.mJointAxes[j].transpose() << endl;
       }
-      cout << "  body inertia: " << endl << rbdl_body.mInertia << endl;
+      cout << "  body inertia: " << endl
+           << rbdl_body.mInertia << endl;
       cout << "  body mass   : " << rbdl_body.mMass << endl;
       cout << "  body name   : " << urdf_child->name << endl;
     }
 
-    if (urdf_joint->type == urdf::Joint::FLOATING) {
+    if (urdf_joint->type == urdf::Joint::FLOATING)
+    {
       Matrix3d zero_matrix = Matrix3d::Zero();
-      Body null_body (0., Vector3d::Zero(3), zero_matrix);
+      Body null_body(0., Vector3d::Zero(3), zero_matrix);
       Joint joint_txtytz(JointTypeTranslationXYZ);
       string trans_body_name = urdf_child->name + "_Translate";
-      rbdl_model->AddBody (rbdl_parent_id, rbdl_joint_frame, joint_txtytz, null_body,
-                           trans_body_name);
+      rbdl_model->AddBody(rbdl_parent_id, rbdl_joint_frame, joint_txtytz, null_body, trans_body_name);
 
-      Joint joint_euler_zyx (JointTypeEulerXYZ);
-      rbdl_model->AppendBody (SpatialTransform(), joint_euler_zyx, rbdl_body,
-                              urdf_child->name);
-    } else {
-      rbdl_model->AddBody (rbdl_parent_id, rbdl_joint_frame, rbdl_joint, rbdl_body,
-                           urdf_child->name);
+      Joint joint_euler_zyx(JointTypeEulerXYZ);
+      rbdl_model->AppendBody(SpatialTransform(), joint_euler_zyx, rbdl_body, urdf_child->name);
+    }
+    else
+    {
+      rbdl_model->AddBody(rbdl_parent_id, rbdl_joint_frame, rbdl_joint, rbdl_body, urdf_child->name);
     }
   }
 
   return true;
 }
 
-RBDL_DLLAPI bool URDFReadFromFile (const char* filename, Model* model,
-                                   bool floating_base, bool verbose)
+RBDL_DLLAPI bool URDFReadFromFile(const char *filename, Model *model, bool floating_base, bool verbose)
 {
-  ifstream model_file (filename);
-  //! [Invalid File]
-  if (!model_file) {
-    ostringstream errormsg;
-    errormsg << "Error opening file '" << filename << "'." << endl;
-    throw Errors::RBDLInvalidFileError(errormsg.str());
+  ifstream model_file(filename);
+  if (!model_file)
+  {
+    cerr << "Error opening file '" << filename << "'." << endl;
+    abort();
   }
-  //! [Invalid File]
 
   // reserve memory for the contents of the file
   string model_xml_string;
   model_file.seekg(0, std::ios::end);
   model_xml_string.reserve(model_file.tellg());
   model_file.seekg(0, std::ios::beg);
-  model_xml_string.assign((std::istreambuf_iterator<char>(model_file)),
-                          std::istreambuf_iterator<char>());
+  model_xml_string.assign((std::istreambuf_iterator<char>(model_file)), std::istreambuf_iterator<char>());
 
   model_file.close();
 
-  return URDFReadFromString (model_xml_string.c_str(), model, floating_base,
-                             verbose);
+  return URDFReadFromString(model_xml_string.c_str(), model, floating_base, verbose);
 }
 
-RBDL_DLLAPI bool URDFReadFromString (const char* model_xml_string, Model* model,
-                                     bool floating_base, bool verbose)
+RBDL_DLLAPI bool URDFReadFromString(const char *model_xml_string, Model *model, bool floating_base, bool verbose)
 {
-  assert (model);
+  assert(model);
 
-  ModelPtr urdf_model = urdf::parseURDF (model_xml_string);
+  ModelPtr urdf_model = urdf::parseURDF(model_xml_string);
 
-  if (!construct_model (model, urdf_model, floating_base, verbose)) {
+  if (!construct_model(model, urdf_model, floating_base, verbose))
+  {
     cerr << "Error constructing model from urdf file." << endl;
     return false;
   }
 
-  model->gravity.set (0., 0., -9.81);
+  model->gravity.set(0., 0., -9.81);
 
   return true;
 }
 
-}
+} // namespace Addons
 
-}
+} // namespace RigidBodyDynamics
+


### PR DESCRIPTION
Build error log when URDFREADER flag is set during build

```bash
Scanning dependencies of target rbdl
[  3%] Building CXX object CMakeFiles/rbdl.dir/src/rbdl_version.cc.o
[  6%] Building CXX object CMakeFiles/rbdl.dir/src/Constraint_Loop.cc.o
[ 13%] Building CXX object CMakeFiles/rbdl.dir/src/rbdl_errors.cc.o
[ 13%] Building CXX object CMakeFiles/rbdl.dir/src/rbdl_mathutils.cc.o
[ 20%] Building CXX object CMakeFiles/rbdl.dir/src/Constraint_Contact.cc.o
[ 20%] Building CXX object CMakeFiles/rbdl.dir/src/rbdl_utils.cc.o
[ 24%] Building CXX object CMakeFiles/rbdl.dir/src/Constraints.cc.o
[ 27%] Building CXX object CMakeFiles/rbdl.dir/src/Dynamics.cc.o
[ 31%] Building CXX object CMakeFiles/rbdl.dir/src/Logging.cc.o
[ 34%] Building CXX object CMakeFiles/rbdl.dir/src/Joint.cc.o
[ 37%] Building CXX object CMakeFiles/rbdl.dir/src/Model.cc.o
[ 41%] Building CXX object CMakeFiles/rbdl.dir/src/Kinematics.cc.o
[ 44%] Linking CXX shared library librbdl.so
[ 44%] Built target rbdl
Scanning dependencies of target rbdl_geometry
Scanning dependencies of target rbdl_luamodel
Scanning dependencies of target rbdl_urdfreader
[ 48%] Building CXX object addons/luamodel/CMakeFiles/rbdl_luamodel.dir/luatables.cc.o
[ 51%] Building CXX object addons/luamodel/CMakeFiles/rbdl_luamodel.dir/luamodel.cc.o
[ 55%] Building CXX object addons/geometry/CMakeFiles/rbdl_geometry.dir/SegmentedQuinticBezierToolkit.cc.o
[ 58%] Building CXX object addons/geometry/CMakeFiles/rbdl_geometry.dir/SmoothSegmentedFunction.cc.o
[ 62%] Building CXX object addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/urdfreader.cc.o
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:15:11: error: ‘boost’ does not name a type; did you mean ‘bool’?
   typedef boost::shared_ptr<urdf::Link> LinkPtr;
           ^~~~~
           bool
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:16:17: error: ‘boost’ does not name a type; did you mean ‘bool’?
   typedef const boost::shared_ptr<const urdf::Link> ConstLinkPtr;
                 ^~~~~
                 bool
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:17:11: error: ‘boost’ does not name a type; did you mean ‘bool’?
   typedef boost::shared_ptr<urdf::Joint> JointPtr;
           ^~~~~
           bool
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:18:11: error: ‘boost’ does not name a type; did you mean ‘bool’?
   typedef boost::shared_ptr<urdf::ModelInterface> ModelPtr;
           ^~~~~
           bool
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:41:16: error: ‘LinkPtr’ was not declared in this scope
 typedef vector<LinkPtr> URDFLinkVector;
                ^~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:41:23: error: template argument 1 is invalid
 typedef vector<LinkPtr> URDFLinkVector;
                       ^
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:41:23: error: template argument 2 is invalid
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:42:16: error: ‘JointPtr’ was not declared in this scope
 typedef vector<JointPtr> URDFJointVector;
                ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:42:16: note: suggested alternative: ‘Joint’
 typedef vector<JointPtr> URDFJointVector;
                ^~~~~~~~
                Joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:42:24: error: template argument 1 is invalid
 typedef vector<JointPtr> URDFJointVector;
                        ^
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:42:24: error: template argument 2 is invalid
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:43:21: error: ‘LinkPtr’ was not declared in this scope
 typedef map<string, LinkPtr > URDFLinkMap;
                     ^~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:43:29: error: template argument 2 is invalid
 typedef map<string, LinkPtr > URDFLinkMap;
                             ^
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:43:29: error: template argument 4 is invalid
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:44:21: error: ‘JointPtr’ was not declared in this scope
 typedef map<string, JointPtr > URDFJointMap;
                     ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:44:21: note: suggested alternative: ‘Joint’
 typedef map<string, JointPtr > URDFJointMap;
                     ^~~~~~~~
                     Joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:44:30: error: template argument 2 is invalid
 typedef map<string, JointPtr > URDFJointMap;
                              ^
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:44:30: error: template argument 4 is invalid
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:46:42: error: ‘ModelPtr’ has not been declared
 bool construct_model (Model* rbdl_model, ModelPtr urdf_model,
                                          ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc: In function ‘bool RigidBodyDynamics::Addons::construct_model(RigidBodyDynamics::Model*, int, bool, bool)’:
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:49:3: error: ‘LinkPtr’ was not declared in this scope
   LinkPtr urdf_root_link;
   ^~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:52:24: error: base operand of ‘->’ is not a pointer
   link_map = urdf_model->links_;
                        ^~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:55:25: error: base operand of ‘->’ is not a pointer
   joint_map = urdf_model->joints_;
                         ^~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:60:17: error: type/value mismatch at argument 1 in template parameter list for ‘template<class _Tp, class _Sequence> class std::stack’
   stack<LinkPtr > link_stack;
                 ^
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:60:17: note:   expected a type, got ‘LinkPtr’
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:60:17: error: template argument 2 is invalid
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:65:14: error: request for member ‘push’ in ‘link_stack’, which is of non-class type ‘int’
   link_stack.push (link_map[(urdf_model->getRoot()->name)]);
              ^~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:65:40: error: base operand of ‘->’ is not a pointer
   link_stack.push (link_map[(urdf_model->getRoot()->name)]);
                                        ^~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:68:3: error: ‘ConstLinkPtr’ was not declared in this scope
   ConstLinkPtr& root = urdf_model->getRoot ();
   ^~~~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:68:3: note: suggested alternative: ‘Constraint’
   ConstLinkPtr& root = urdf_model->getRoot ();
   ^~~~~~~~~~~~
   Constraint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:68:17: error: ‘root’ was not declared in this scope
   ConstLinkPtr& root = urdf_model->getRoot ();
                 ^~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:68:17: note: suggested alternative: ‘rint’
   ConstLinkPtr& root = urdf_model->getRoot ();
                 ^~~~
                 rint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:68:34: error: base operand of ‘->’ is not a pointer
   ConstLinkPtr& root = urdf_model->getRoot ();
                                  ^~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:130:21: error: request for member ‘size’ in ‘link_stack’, which is of non-class type ‘int’
   while (link_stack.size() > 0) {
                     ^~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:131:13: error: expected ‘;’ before ‘cur_link’
     LinkPtr cur_link = link_stack.top();
             ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:136:21: error: ‘cur_link’ was not declared in this scope
     if (joint_idx < cur_link->child_joints.size()) {
                     ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:136:21: note: suggested alternative: ‘u_long’
     if (joint_idx < cur_link->child_joints.size()) {
                     ^~~~~~~~
                     u_long
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:137:7: error: ‘JointPtr’ was not declared in this scope
       JointPtr cur_joint = cur_link->child_joints[joint_idx];
       ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:137:7: note: suggested alternative: ‘Joint’
       JointPtr cur_joint = cur_link->child_joints[joint_idx];
       ^~~~~~~~
       Joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:143:18: error: request for member ‘push’ in ‘link_stack’, which is of non-class type ‘int’
       link_stack.push (link_map[cur_joint->child_link_name]);
                  ^~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:143:33: error: ‘cur_joint’ was not declared in this scope
       link_stack.push (link_map[cur_joint->child_link_name]);
                                 ^~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:143:33: note: suggested alternative: ‘u_int’
       link_stack.push (link_map[cur_joint->child_link_name]);
                                 ^~~~~~~~~
                                 u_int
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:151:25: error: request for member ‘top’ in ‘link_stack’, which is of non-class type ‘int’
              link_stack.top()->name << "' type = " << cur_joint->type << endl;
                         ^~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:156:18: error: request for member ‘pop’ in ‘link_stack’, which is of non-class type ‘int’
       link_stack.pop();
                  ^~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:163:5: error: ‘JointPtr’ was not declared in this scope
     JointPtr urdf_joint = joint_map[joint_names[j]];
     ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:163:5: note: suggested alternative: ‘Joint’
     JointPtr urdf_joint = joint_map[joint_names[j]];
     ^~~~~~~~
     Joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:164:13: error: expected ‘;’ before ‘urdf_parent’
     LinkPtr urdf_parent = link_map[urdf_joint->parent_link_name];
             ^~~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:165:13: error: expected ‘;’ before ‘urdf_child’
     LinkPtr urdf_child = link_map[urdf_joint->child_link_name];
             ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:171:9: error: ‘urdf_parent’ was not declared in this scope
     if (urdf_parent->name != "base_link"
         ^~~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:171:9: note: suggested alternative: ‘urdf_model’
     if (urdf_parent->name != "base_link"
         ^~~~~~~~~~~
         urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:177:51: error: ‘urdf_joint’ was not declared in this scope
       cerr << "Error while processing joint '" << urdf_joint->name
                                                   ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:177:51: note: suggested alternative: ‘urdf_model’
       cerr << "Error while processing joint '" << urdf_joint->name
                                                   ^~~~~~~~~~
                                                   urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:178:37: error: ‘urdf_parent’ was not declared in this scope
            << "': parent link '" << urdf_parent->name
                                     ^~~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:178:37: note: suggested alternative: ‘urdf_model’
            << "': parent link '" << urdf_parent->name
                                     ^~~~~~~~~~~
                                     urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:185:9: error: ‘urdf_joint’ was not declared in this scope
     if (urdf_joint->type == urdf::Joint::REVOLUTE ||
         ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:185:9: note: suggested alternative: ‘rbdl_joint’
     if (urdf_joint->type == urdf::Joint::REVOLUTE ||
         ^~~~~~~~~~
         rbdl_joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:214:5: error: ‘urdf_joint’ was not declared in this scope
     urdf_joint->parent_to_joint_origin_transform.rotation.getRPY (joint_rpy[0],
     ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:214:5: note: suggested alternative: ‘rbdl_joint’
     urdf_joint->parent_to_joint_origin_transform.rotation.getRPY (joint_rpy[0],
     ^~~~~~~~~~
     rbdl_joint
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:236:9: error: ‘urdf_child’ was not declared in this scope
     if (urdf_child->inertial) {
         ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:236:9: note: suggested alternative: ‘urdf_model’
     if (urdf_child->inertial) {
         ^~~~~~~~~~
         urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:271:36: error: ‘urdf_child’ was not declared in this scope
       cout << "+ Adding Body: " << urdf_child->name << endl;
                                    ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:271:36: note: suggested alternative: ‘urdf_model’
       cout << "+ Adding Body: " << urdf_child->name << endl;
                                    ^~~~~~~~~~
                                    urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:287:32: error: ‘urdf_child’ was not declared in this scope
       string trans_body_name = urdf_child->name + "_Translate";
                                ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:287:32: note: suggested alternative: ‘urdf_model’
       string trans_body_name = urdf_child->name + "_Translate";
                                ^~~~~~~~~~
                                urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:296:28: error: ‘urdf_child’ was not declared in this scope
                            urdf_child->name);
                            ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:296:28: note: suggested alternative: ‘urdf_model’
                            urdf_child->name);
                            ^~~~~~~~~~
                            urdf_model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc: In function ‘bool RigidBodyDynamics::Addons::URDFReadFromString(const char*, RigidBodyDynamics::Model*, bool, bool)’:
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:334:3: error: ‘ModelPtr’ was not declared in this scope
   ModelPtr urdf_model = urdf::parseURDF (model_xml_string);
   ^~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:334:3: note: suggested alternative: ‘Model’
   ModelPtr urdf_model = urdf::parseURDF (model_xml_string);
   ^~~~~~~~
   Model
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:336:32: error: ‘urdf_model’ was not declared in this scope
   if (!construct_model (model, urdf_model, floating_base, verbose)) {
                                ^~~~~~~~~~
/home/dhruv/rbdl-orb/addons/urdfreader/urdfreader.cc:336:32: note: suggested alternative: ‘model’
   if (!construct_model (model, urdf_model, floating_base, verbose)) {
                                ^~~~~~~~~~
                                model
[ 65%] Linking CXX shared library librbdl_geometry.so
[ 65%] Built target rbdl_geometry
addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/build.make:62: recipe for target 'addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/urdfreader.cc.o' failed
make[2]: *** [addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/urdfreader.cc.o] Error 1
CMakeFiles/Makefile2:669: recipe for target 'addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/all' failed
make[1]: *** [addons/urdfreader/CMakeFiles/rbdl_urdfreader.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 68%] Linking CXX shared library librbdl_luamodel.so
[ 68%] Built target rbdl_luamodel
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
```

Successfully fixed issue by modifying urdfreader.

Tested on Ubuntu 18.04 with ROS Melodic.

TODO: 
Run a test with ROS Kinetic urdfreader packages (although deprecated) **if required**.