### PR TITLE
Luamodelupdates

### DIFF
--- a/addons/luamodel/luamodel.cc
+++ b/addons/luamodel/luamodel.cc
@@ -57,48 +57,48 @@ bool LuaModelReadFromLuaState (lua_State* L, Model* model, bool verbose)
 bool LuaModelReadLocalFrames (
       LuaTable &model_table,
       const RigidBodyDynamics::Model *model,
-      std::vector<LocalFrame>& updLocalFramesSet,
+      std::vector<LocalFrame>& upd_local_frame_set,
       bool verbose);
 
 RBDL_DLLAPI
 bool LuaModelReadLocalFrames (
       const char* filename,
       const RigidBodyDynamics::Model *model,
-      std::vector<LocalFrame>& updLocalFramesSet,
+      std::vector<LocalFrame>& upd_local_frame_set,
       bool verbose)
 {
   LuaTable model_table       = LuaTable::fromFile (filename);
-  return LuaModelReadLocalFrames(model_table,model,updLocalFramesSet,verbose);
+  return LuaModelReadLocalFrames(model_table,model,upd_local_frame_set,verbose);
 }
 
 //==============================================================================
 bool LuaModelReadPoints (
       LuaTable &model_table,
       const RigidBodyDynamics::Model *model,
-      std::vector<Point>& updPointSet,
+      std::vector<Point>& upd_point_set,
       bool verbose);
 
 RBDL_DLLAPI
 bool LuaModelReadPoints (
       const char* filename,
       const RigidBodyDynamics::Model *model,
-      std::vector<Point>& updPointSet,
+      std::vector<Point>& upd_point_set,
       bool verbose)
 {
   LuaTable model_table       = LuaTable::fromFile (filename);
-  return LuaModelReadPoints(model_table,model,updPointSet,verbose);
+  return LuaModelReadPoints(model_table,model,upd_point_set,verbose);
 }
 
 //==============================================================================
 RBDL_DLLAPI
-bool LuaModelReadFromFile (const char* filename, Model* updModel, bool verbose)
+bool LuaModelReadFromFile (const char* filename, Model* upd_model, bool verbose)
 {
-  if(!updModel) {
+  if(!upd_model) {
     throw Errors::RBDLError("Model not provided.");
   }
 
   LuaTable model_table = LuaTable::fromFile (filename);
-  return LuaModelReadFromTable (model_table, updModel, verbose);
+  return LuaModelReadFromTable (model_table, upd_model, verbose);
 }
 
 //==============================================================================
@@ -120,7 +120,9 @@ std::vector<std::string> LuaModelGetConstraintSetNames(const char* filename)
 
   for (size_t ci = 0; ci < constraint_keys.size(); ++ci) {
     if (constraint_keys[ci].type != LuaKey::String) {
-      throw Errors::RBDLFileParseError("Invalid constraint found in model.constraint_sets: no constraint set name was specified!");
+      throw Errors::RBDLFileParseError(
+            "Invalid constraint found in model.constraint_sets: "
+            "no constraint set name was specified!");
     }
 
     result.push_back(constraint_keys[ci].string_value);
@@ -143,7 +145,9 @@ bool LuaModelReadFromFileWithConstraints (
     throw Errors::RBDLError("Model not provided.");
   }
   if(constraint_sets.size() != constraint_set_names.size()) {
-    throw Errors::RBDLFileParseError("Number of constraint sets different from the number of constraint set names.");
+    throw Errors::RBDLFileParseError(
+          "Number of constraint sets different from"
+          " the number of constraint set names.");
   }
 
   LuaTable model_table = LuaTable::fromFile (filename);
@@ -356,7 +360,8 @@ bool LuaModelReadConstraintsFromTable (
             std::ostringstream errormsg;
             errormsg << "The normal_sets field must be m x 3, the one read for "
                      << conName.c_str() << " has an normal_sets of size "
-                     << normalSetsMatrix.rows() << " x " << normalSetsMatrix.cols()
+                     << normalSetsMatrix.rows() << " x "
+                     << normalSetsMatrix.cols()
                      << ". In addition the normal_sets field should resemble:"
                      << endl;
             errormsg << "  normal_sets = {{1.,0.,0.,}, " << endl;
@@ -424,9 +429,9 @@ bool LuaModelReadConstraintsFromTable (
         unsigned int constraint_user_id=std::numeric_limits<unsigned int>::max();
         if(model_table["constraint_sets"][conName.c_str()][ci + 1]
             ["id"].exists()) {
-          constraint_user_id = unsigned(int(
-                                          model_table["constraint_sets"][conName.c_str()]
-                                          [ci + 1]["id"].getDefault<double>(0.)));
+          constraint_user_id =
+              unsigned(int(model_table["constraint_sets"][conName.c_str()]
+                           [ci + 1]["id"].getDefault<double>(0.)));
         }
 
         //Get the local frames that this constraint will be applied to
@@ -465,7 +470,8 @@ bool LuaModelReadConstraintsFromTable (
         }else{
           if(!model_table["constraint_sets"][conName.c_str()]
               [ci + 1]["predecessor_body"].exists()) {
-            throw Errors::RBDLFileParseError("predecessor_body not specified.\n");
+            throw Errors::RBDLFileParseError(
+                  "predecessor_body not specified.\n");
           }
 
           idPredecessor =
@@ -625,12 +631,12 @@ bool LuaModelReadConstraintsFromTable (
 bool LuaModelReadMotionCaptureMarkers (
       const char* filename,
       const RigidBodyDynamics::Model *model,
-      std::vector<Point>& updPointSet,
+      std::vector<Point>& upd_point_set,
       bool verbose)
 {
 
   LuaTable luaTable       = LuaTable::fromFile (filename);
-  updPointSet.clear();
+  upd_point_set.clear();
 
   if(luaTable["frames"].exists()){
     unsigned int frameCount = luaTable["frames"].length();
@@ -655,7 +661,7 @@ bool LuaModelReadMotionCaptureMarkers (
           point.body_id   = body_id;
           point.point_local = luaTable["frames"][i]["markers"][point.name.c_str()]
                               .getDefault<Vector3d>(Vector3d::Zero());
-          updPointSet.push_back(point);
+          upd_point_set.push_back(point);
         }
       }
     }
@@ -667,16 +673,16 @@ bool LuaModelReadMotionCaptureMarkers (
 bool LuaModelReadLocalFrames (
       LuaTable &model_table,
       const RigidBodyDynamics::Model *model,
-      std::vector<LocalFrame>& updLocalFramesSet,
+      std::vector<LocalFrame>& upd_local_frame_set,
       bool verbose)
 {
   //LuaTable luaTable       = LuaTable::fromFile (filename);
-  updLocalFramesSet.clear();
+  upd_local_frame_set.clear();
   unsigned int localFrameCount =
       unsigned(int(model_table["local_frames"].length()));
 
   if(localFrameCount > 0){
-    updLocalFramesSet.resize(localFrameCount);
+    upd_local_frame_set.resize(localFrameCount);
     LocalFrame localFrame;
 
     for (unsigned int i = 1; i <= localFrameCount; ++i) {
@@ -684,15 +690,15 @@ bool LuaModelReadLocalFrames (
       localFrame = model_table["local_frames"][signed(i)];
 
       localFrame.body_id     = model->GetBodyId (localFrame.body_name.c_str());
-      updLocalFramesSet[i-1] = localFrame;
+      upd_local_frame_set[i-1] = localFrame;
 
       if (verbose) {
-        cout  << "LocalFrame '" << updLocalFramesSet[i-1].name
-              << "' (name = "   << updLocalFramesSet[i-1].name << ")" << endl;
-        cout  << "  body        = " << updLocalFramesSet[i-1].body_name
-              << " (id = " << updLocalFramesSet[i-1].body_id << ")" << endl;
-        cout  << "  r  = '" << updLocalFramesSet[i-1].r.transpose() << endl;
-        cout  << "  E  = '" << updLocalFramesSet[i-1].E << endl;
+        cout  << "LocalFrame '" << upd_local_frame_set[i-1].name
+              << "' (name = "   << upd_local_frame_set[i-1].name << ")" << endl;
+        cout  << "  body        = " << upd_local_frame_set[i-1].body_name
+              << " (id = " << upd_local_frame_set[i-1].body_id << ")" << endl;
+        cout  << "  r  = '" << upd_local_frame_set[i-1].r.transpose() << endl;
+        cout  << "  E  = '" << upd_local_frame_set[i-1].E << endl;
       }
     }
   }
@@ -703,15 +709,15 @@ bool LuaModelReadLocalFrames (
 bool LuaModelReadPoints (
       LuaTable &model_table,
       const RigidBodyDynamics::Model *model,
-      std::vector<Point>& updPointSet,
+      std::vector<Point>& upd_point_set,
       bool verbose)
 {
 
-  updPointSet.clear();
+  upd_point_set.clear();
   unsigned int pointCount = unsigned(int(model_table["points"].length()));
 
   if(pointCount > 0){
-    updPointSet.resize(pointCount);
+    upd_point_set.resize(pointCount);
     Point point;
 
     for (unsigned int i = 1; i <= pointCount; ++i) {
@@ -719,14 +725,14 @@ bool LuaModelReadPoints (
       point = model_table["points"][i];
 
       point.body_id   = model->GetBodyId (point.body_name.c_str());
-      updPointSet[i-1]   = point;
+      upd_point_set[i-1]   = point;
 
       if (verbose) {
-        cout  << "Point '"           << updPointSet[i-1].name
-              << "' (PointName = "   << updPointSet[i-1].name << ")"    << endl;
-        cout  << "  body        = "  << updPointSet[i-1].body_name
-              << " (id = "           << updPointSet[i-1].body_id << ")" << endl;
-        cout  << "  point_local  = '"       << updPointSet[i-1].point_local.transpose()
+        cout  << "Point '"           << upd_point_set[i-1].name
+              << "' (PointName = "   << upd_point_set[i-1].name << ")"    << endl;
+        cout  << "  body        = "  << upd_point_set[i-1].body_name
+              << " (id = "           << upd_point_set[i-1].body_id << ")" << endl;
+        cout  << "  point_local  = '"       << upd_point_set[i-1].point_local.transpose()
                                      << endl;
       }
     }

--- a/addons/luamodel/luamodel.h
+++ b/addons/luamodel/luamodel.h
@@ -4,6 +4,7 @@
 #include <rbdl/rbdl_config.h>
 #include <string>
 #include <vector>
+#include "luastructs.h"
 
 extern "C" {
   struct lua_State;
@@ -269,6 +270,43 @@ bool LuaModelReadFromFile (
 RBDL_DLLAPI
 std::vector<std::string> LuaModelGetConstraintSetNames(const char* filename);
 
+/**
+  This function will load named body-fixed motion capture markers that are
+  attached to each body
+
+  @param filename: name of the lua file
+  @param model: reference to the multibody model.
+  @param pointSet: an empty std::vector of Point structure
+  @param verbose: information will be printed to the command window if this
+                  is set to true.
+
+*/
+RBDL_DLLAPI
+bool LuaModelReadMotionCaptureMarkers (
+      const char* filename,
+      Model* model,
+      std::vector<Point> &markerSet,
+      bool verbose=false);
+
+/**
+  This function will load the point information from the lua
+  file into the std::vector of Point structures.
+
+  @param filename: name of the lua file
+  @param model: reference to the multibody model.
+  @param pointSet: an empty std::vector of Point structurs
+  @param verbose: information will be printed to the command window if this
+                  is set to true.
+
+*/
+RBDL_DLLAPI
+bool LuaModelReadPoints (
+      const char* filename,
+      Model* model,
+      std::vector<Point> &pointSet,
+      bool verbose=false);
+
+
 /** \brief Reads a model and constraint sets from a Lua file.
  *
  * \param filename the name of the Lua file.
@@ -308,6 +346,7 @@ bool LuaModelReadFromLuaState (
   lua_State* L,
   Model* model,
   bool verbose = false);
+
 
 /** @} */
 }

--- a/addons/luamodel/luamodel.h
+++ b/addons/luamodel/luamodel.h
@@ -262,7 +262,7 @@ namespace Addons {
 RBDL_DLLAPI
 bool LuaModelReadFromFile (
   const char* filename,
-  Model* model,
+  Model* updModel,
   bool verbose = false);
 
 /** \brief Reads a model file and returns the names of all constraint sets.
@@ -275,7 +275,7 @@ std::vector<std::string> LuaModelGetConstraintSetNames(const char* filename);
   attached to each body
 
   @param filename: name of the lua file
-  @param model: reference to the multibody model.
+  @param model: reference to the (loaded) multibody model.
   @param pointSet: an empty std::vector of Point structure
   @param verbose: information will be printed to the command window if this
                   is set to true.
@@ -284,7 +284,7 @@ std::vector<std::string> LuaModelGetConstraintSetNames(const char* filename);
 RBDL_DLLAPI
 bool LuaModelReadMotionCaptureMarkers (
       const char* filename,
-      Model* model,
+      const Model* model,
       std::vector<Point> &markerSet,
       bool verbose=false);
 
@@ -293,7 +293,7 @@ bool LuaModelReadMotionCaptureMarkers (
   file into the std::vector of Point structures.
 
   @param filename: name of the lua file
-  @param model: reference to the multibody model.
+  @param model: reference to the (loaded) multibody model.
   @param pointSet: an empty std::vector of Point structurs
   @param verbose: information will be printed to the command window if this
                   is set to true.
@@ -302,8 +302,26 @@ bool LuaModelReadMotionCaptureMarkers (
 RBDL_DLLAPI
 bool LuaModelReadPoints (
       const char* filename,
-      Model* model,
+      const Model* model,
       std::vector<Point> &pointSet,
+      bool verbose=false);
+
+/**
+  This function will load the local frames from the lua
+  file into the std::vector of LocalFrame structures.
+
+  @param filename: name of the lua file
+  @param model: reference to the (loaded) multibody model.
+  @param localFrameSet: an empty std::vector of LocalFrame structurs
+  @param verbose: information will be printed to the command window if this
+                  is set to true.
+
+*/
+RBDL_DLLAPI
+bool LuaModelReadLocalFrames (
+      const char* filename,
+      const Model* model,
+      std::vector<LocalFrame> &updLocalFrameSet,
       bool verbose=false);
 
 

--- a/addons/luamodel/luamodel.h
+++ b/addons/luamodel/luamodel.h
@@ -250,7 +250,7 @@ namespace Addons {
 /** \brief Reads a model from a Lua file.
  *
  * \param filename the name of the Lua file.
- * \param model a pointer to the output Model structure.
+ * \param upd_model a pointer to the output Model structure.
  * \param verbose specifies wether information on the model should be printed
  * (default: true).
  *
@@ -262,7 +262,7 @@ namespace Addons {
 RBDL_DLLAPI
 bool LuaModelReadFromFile (
   const char* filename,
-  Model* updModel,
+  Model* upd_model,
   bool verbose = false);
 
 /** \brief Reads a model file and returns the names of all constraint sets.
@@ -276,7 +276,7 @@ std::vector<std::string> LuaModelGetConstraintSetNames(const char* filename);
 
   @param filename: name of the lua file
   @param model: reference to the (loaded) multibody model.
-  @param pointSet: an empty std::vector of Point structure
+  @param upd_marker_set: an empty std::vector of Point structure
   @param verbose: information will be printed to the command window if this
                   is set to true.
 
@@ -285,7 +285,7 @@ RBDL_DLLAPI
 bool LuaModelReadMotionCaptureMarkers (
       const char* filename,
       const Model* model,
-      std::vector<Point> &markerSet,
+      std::vector<Point> &upd_marker_set,
       bool verbose=false);
 
 /**
@@ -294,7 +294,7 @@ bool LuaModelReadMotionCaptureMarkers (
 
   @param filename: name of the lua file
   @param model: reference to the (loaded) multibody model.
-  @param pointSet: an empty std::vector of Point structurs
+  @param upd_point_set: an empty std::vector of Point structurs
   @param verbose: information will be printed to the command window if this
                   is set to true.
 
@@ -303,7 +303,7 @@ RBDL_DLLAPI
 bool LuaModelReadPoints (
       const char* filename,
       const Model* model,
-      std::vector<Point> &pointSet,
+      std::vector<Point> &upd_point_set,
       bool verbose=false);
 
 /**
@@ -312,7 +312,7 @@ bool LuaModelReadPoints (
 
   @param filename: name of the lua file
   @param model: reference to the (loaded) multibody model.
-  @param localFrameSet: an empty std::vector of LocalFrame structurs
+  @param upd_local_frame_set: an empty std::vector of LocalFrame structurs
   @param verbose: information will be printed to the command window if this
                   is set to true.
 
@@ -321,14 +321,14 @@ RBDL_DLLAPI
 bool LuaModelReadLocalFrames (
       const char* filename,
       const Model* model,
-      std::vector<LocalFrame> &updLocalFrameSet,
+      std::vector<LocalFrame> &upd_local_frame_set,
       bool verbose=false);
 
 
 /** \brief Reads a model and constraint sets from a Lua file.
  *
  * \param filename the name of the Lua file.
- * \param model a pointer to the output Model structure.
+ * \param upd_model a pointer to the output Model structure.
  * \param constraint_sets reference to a std::vector of ConstraintSet structures
  * in which to save the information read from the file.
  * \param constraint_set_names reference to a std::vector of std::string
@@ -345,7 +345,7 @@ bool LuaModelReadLocalFrames (
 RBDL_DLLAPI
 bool LuaModelReadFromFileWithConstraints (
   const char* filename,
-  Model* model,
+  Model* upd_model,
   std::vector<ConstraintSet>& constraint_sets,
   const std::vector<std::string>& constraint_set_names,
   bool verbose = false);

--- a/addons/luamodel/luastructs.h
+++ b/addons/luamodel/luastructs.h
@@ -80,6 +80,40 @@ struct MotionCaptureMarker {
   RigidBodyDynamics::Math::Vector3d point_local;
 };
 
+/**
+  A struct for a named body fixed frame.
 
+  @param name the name of the point
+  @param body_id the integer id of the body that this local frame is fixed to
+  @param body_name the name of the body that this local frame is fixed to
+  @param r the translation from the body's origin to the origin of the
+         local frame, in the coordinates of the body.
+  @param E the rotation matrix that transforms vectors from the
+         coordinates of the local frame to the coordinates of the body.
+*/
+struct LocalFrame {
+  LocalFrame() :
+    name ("unknown"),
+    body_id (std::numeric_limits<unsigned int>::signaling_NaN()),
+    body_name (""),
+    r ( std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN()),
+    E ( std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN(),
+        std::numeric_limits<double>::signaling_NaN())
+  { }
+  std::string name;
+  unsigned int body_id;
+  std::string body_name;
+  RigidBodyDynamics::Math::Vector3d r;
+  RigidBodyDynamics::Math::Matrix3d E;
+};
 /* LUASTRUCTS_H */
 #endif

--- a/addons/luamodel/luastructs.h
+++ b/addons/luamodel/luastructs.h
@@ -1,0 +1,85 @@
+//==============================================================================
+/* 
+ * RBDL - Rigid Body Dynamics Library: Addon : luamodel structs
+ * Copyright (c) 2020 Matthew Millard <millard.matthew@gmail.com>
+ *
+ * Licensed under the zlib license. See LICENSE for more details.
+ */
+
+#ifndef LUASTRUCTS_H
+#define LUASTRUCTS_H
+
+#include <iostream>
+#include <sstream>
+#include <assert.h>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include <limits>
+#include <rbdl/rbdl_math.h>
+
+#include <rbdl/rbdl_config.h>
+#include <rbdl/rbdl_errors.h>
+
+/**
+  A struct for a named body-fixed-point. The names used in this
+  struct should be updated but remain as seen below for historical
+  reasons. In the future perhaps something clearer such as
+  BodyFixedPoint should be used with fields of name, body_id,
+  body_name, and r.
+
+  @param name the name of the point
+  @param body_id the integer id of the body that this point is fixed to
+  @param body_name the name of the body that this point is fixed to
+  @param point_local the coordinates of this point relative to the body's
+          origin in the coordinates of the body.
+*/
+struct Point {
+  Point() :
+    name ("unknown"),
+    body_id (std::numeric_limits<unsigned int>::signaling_NaN()),
+    body_name (""),
+    point_local (
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()
+      )
+  { }
+
+  std::string name;
+  unsigned int body_id;
+  std::string body_name;
+  RigidBodyDynamics::Math::Vector3d point_local;
+};
+
+/**
+  A struct for a named motion capture marker.
+
+  @param name the name of the marker
+  @param body_id the integer id of the body that this point is fixed to
+  @param body_name the name of the body that this point is fixed to
+  @param point_local the coordinates of this point relative to the body's
+          origin in the coordinates of the body.
+*/
+struct MotionCaptureMarker {
+  MotionCaptureMarker() :
+    name ("unknown"),
+    body_id (std::numeric_limits<unsigned int>::signaling_NaN()),
+    body_name (""),
+    point_local (
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN(),
+      std::numeric_limits<double>::signaling_NaN()
+      )
+  { }
+
+  std::string name;
+  unsigned int body_id;
+  std::string body_name;
+  RigidBodyDynamics::Math::Vector3d point_local;
+};
+
+
+/* LUASTRUCTS_H */
+#endif

--- a/addons/luamodel/luatypes.h
+++ b/addons/luamodel/luatypes.h
@@ -327,7 +327,9 @@ LuaTableNode::getDefault<Point>(
     LuaTable point_table = LuaTable::fromLuaState (luaTable->L);
 
     result.name         = point_table["name"].get<std::string>();
-    result.point_local  = point_table["point"];
+    result.point_local  = point_table["point"]
+                            .getDefault<RigidBodyDynamics::Math::Vector3d>(
+                              RigidBodyDynamics::Math::Vector3d::Zero());
     result.body_name    = point_table["body"].get<std::string>();
   }
 
@@ -347,10 +349,11 @@ LuaTableNode::getDefault<MotionCaptureMarker>(
   if (stackQueryValue()) {
     LuaTable marker_table = LuaTable::fromLuaState (luaTable->L);
 
-    result.name         = marker_table["name"].get<std::string>();
-    result.point_local  = marker_table["point"]
-                            .getDefault<RigidBodyDynamics::Math::Vector3d>(
-                              result.point_local);
+    result.name        = marker_table["name"].get<std::string>();
+    result.point_local = marker_table["point"]
+                          .getDefault<RigidBodyDynamics::Math::Vector3d>(
+                            RigidBodyDynamics::Math::Vector3d::Zero());
+    result.body_name   = marker_table["body"].get<std::string>();
   }
 
   stackRestore();
@@ -369,12 +372,15 @@ LuaTableNode::getDefault<LocalFrame>(
   if (stackQueryValue()) {
     LuaTable local_frame_table = LuaTable::fromLuaState (luaTable->L);
 
-    result.name      = local_frame_table["name"].get<std::string>();
-    result.body_name = local_frame_table["body"].get<std::string>();
+    result.name     = local_frame_table["name"].get<std::string>();
+    result.body_name= local_frame_table["body"].get<std::string>();
+
     result.r = local_frame_table["r"]
-                .getDefault<RigidBodyDynamics::Math::Vector3d>(result.r);
+                .getDefault<RigidBodyDynamics::Math::Vector3d>(
+                  RigidBodyDynamics::Math::Vector3d::Zero());
     result.E = local_frame_table["E"]
-                .getDefault<RigidBodyDynamics::Math::Matrix3d>(result.E);
+                .getDefault<RigidBodyDynamics::Math::Matrix3d>(
+                  RigidBodyDynamics::Math::Matrix3d::Identity());
   }
 
   stackRestore();

--- a/addons/luamodel/luatypes.h
+++ b/addons/luamodel/luatypes.h
@@ -348,7 +348,33 @@ LuaTableNode::getDefault<MotionCaptureMarker>(
     LuaTable marker_table = LuaTable::fromLuaState (luaTable->L);
 
     result.name         = marker_table["name"].get<std::string>();
-    result.point_local  = marker_table["point"];
+    result.point_local  = marker_table["point"]
+                            .getDefault<RigidBodyDynamics::Math::Vector3d>(
+                              result.point_local);
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+
+template<> LocalFrame
+LuaTableNode::getDefault<LocalFrame>(
+  const LocalFrame &default_value)
+{
+  LocalFrame result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable local_frame_table = LuaTable::fromLuaState (luaTable->L);
+
+    result.name      = local_frame_table["name"].get<std::string>();
+    result.body_name = local_frame_table["body"].get<std::string>();
+    result.r = local_frame_table["r"]
+                .getDefault<RigidBodyDynamics::Math::Vector3d>(result.r);
+    result.E = local_frame_table["E"]
+                .getDefault<RigidBodyDynamics::Math::Matrix3d>(result.E);
   }
 
   stackRestore();

--- a/addons/luamodel/luatypes.h
+++ b/addons/luamodel/luatypes.h
@@ -1,0 +1,359 @@
+//==============================================================================
+/* 
+ * RBDL - Rigid Body Dynamics Library: Addon : luamodel types
+ * Copyright (c) 2013 Martin Felis <martin@fyxs.org>.
+ *               2020  Matthew Millard <millard.matthew@gmail.com> (extension)
+ *
+ * Licensed under the zlib license. See LICENSE for more details.
+ */
+
+#ifndef LUATYPES_H
+#define LUATYPES_H
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <assert.h>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include <rbdl/rbdl.h>
+#include <rbdl/rbdl_math.h>
+
+#include <rbdl/rbdl_config.h>
+#include <rbdl/rbdl_errors.h>
+
+#include "luastructs.h"
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Math::Vector3d
+LuaTableNode::getDefault<RigidBodyDynamics::Math::Vector3d>(
+    const RigidBodyDynamics::Math::Vector3d &default_value)
+{
+  RigidBodyDynamics::Math::Vector3d result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    if (vector_table.length() != 3) {
+      throw RigidBodyDynamics::Errors::RBDLFileParseError(
+            "LuaModel Error: invalid 3d vector!");
+    }
+
+    result[0] = vector_table[1];
+    result[1] = vector_table[2];
+    result[2] = vector_table[3];
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Math::SpatialVector
+LuaTableNode::getDefault<RigidBodyDynamics::Math::SpatialVector>(
+  const RigidBodyDynamics::Math::SpatialVector &default_value
+)
+{
+  RigidBodyDynamics::Math::SpatialVector result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+  //! [Parse Failed]
+    if (vector_table.length() != 6) {
+      throw RigidBodyDynamics::Errors::RBDLFileParseError(
+            "LuaModel Error: invalid 6d vector!");
+    }
+  //! [Parse Failed]
+
+    result[0] = vector_table[1];
+    result[1] = vector_table[2];
+    result[2] = vector_table[3];
+    result[3] = vector_table[4];
+    result[4] = vector_table[5];
+    result[5] = vector_table[6];
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Math::MatrixNd
+LuaTableNode::getDefault<RigidBodyDynamics::Math::MatrixNd>(
+    const RigidBodyDynamics::Math::MatrixNd &default_value)
+{
+  RigidBodyDynamics::Math::MatrixNd result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    result.resize( int(vector_table.length()),
+                   int(vector_table[1].length()));
+
+    for(int r=0; r<int(vector_table.length()); ++r) {
+      for(int c=0; c<int(vector_table[1].length()); ++c) {
+        result(r,c) = vector_table[r+1][c+1];
+      }
+    }
+  }
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Math::Matrix3d
+LuaTableNode::getDefault<RigidBodyDynamics::Math::Matrix3d>(
+    const RigidBodyDynamics::Math::Matrix3d &default_value)
+{
+  RigidBodyDynamics::Math::Matrix3d result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    if (vector_table.length() != 3) {
+      throw RigidBodyDynamics::Errors::RBDLFileParseError(
+            "LuaModel Error: invalid 3d matrix!");
+    }
+
+    if (vector_table[1].length() != 3
+        || vector_table[2].length() != 3
+        || vector_table[3].length() != 3) {
+      throw RigidBodyDynamics::Errors::RBDLFileParseError(
+            "LuaModel Error: invalid 3d matrix!");
+    }
+
+    result(0,0) = vector_table[1][1];
+    result(0,1) = vector_table[1][2];
+    result(0,2) = vector_table[1][3];
+
+    result(1,0) = vector_table[2][1];
+    result(1,1) = vector_table[2][2];
+    result(1,2) = vector_table[2][3];
+
+    result(2,0) = vector_table[3][1];
+    result(2,1) = vector_table[3][2];
+    result(2,2) = vector_table[3][3];
+  }
+
+  stackRestore();
+
+  return result;
+}
+//==============================================================================
+template<>
+RigidBodyDynamics::Math::SpatialTransform
+LuaTableNode::getDefault<RigidBodyDynamics::Math::SpatialTransform>(
+  const RigidBodyDynamics::Math::SpatialTransform &default_value
+)
+{
+  RigidBodyDynamics::Math::SpatialTransform result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    result.r = vector_table["r"].getDefault<RigidBodyDynamics::Math::Vector3d>(
+          RigidBodyDynamics::Math::Vector3d::Zero(3));
+    result.E = vector_table["E"].getDefault<RigidBodyDynamics::Math::Matrix3d>(
+          RigidBodyDynamics::Math::Matrix3d::Identity (3,3));
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Joint
+LuaTableNode::getDefault<RigidBodyDynamics::Joint>(
+    const RigidBodyDynamics::Joint &default_value)
+{
+  RigidBodyDynamics::Joint result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    int joint_dofs = vector_table.length();
+
+    if (joint_dofs == 1) {
+      std::string dof_string = vector_table[1].getDefault<std::string>("");
+      if (dof_string == "JointTypeSpherical") {
+        stackRestore();
+        return RigidBodyDynamics::Joint(
+              RigidBodyDynamics::JointTypeSpherical);
+      } else if (dof_string == "JointTypeEulerZYX") {
+        stackRestore();
+        return RigidBodyDynamics::Joint(
+              RigidBodyDynamics::JointTypeEulerZYX);
+      }
+      if (dof_string == "JointTypeEulerXYZ") {
+        stackRestore();
+        return RigidBodyDynamics::Joint(
+              RigidBodyDynamics::JointTypeEulerXYZ);
+      }
+      if (dof_string == "JointTypeEulerYXZ") {
+        stackRestore();
+        return RigidBodyDynamics::Joint(
+              RigidBodyDynamics::JointTypeEulerYXZ);
+      }
+      if (dof_string == "JointTypeTranslationXYZ") {
+        stackRestore();
+        return RigidBodyDynamics::Joint(
+              RigidBodyDynamics::JointTypeTranslationXYZ);
+      }
+    }
+
+    if (joint_dofs > 0) {
+      if (vector_table[1].length() != 6) {
+        std::ostringstream errormsg;
+        errormsg << "LuaModel Error: invalid joint motion "
+                 << "subspace description at "
+                 << this->keyStackToString() << std::endl;
+        throw RigidBodyDynamics::Errors::RBDLFileParseError(errormsg.str());
+      }
+    }
+    switch (joint_dofs) {
+    case 0:
+      result = RigidBodyDynamics::Joint(
+            RigidBodyDynamics::JointTypeFixed);
+      break;
+    case 1:
+      result = RigidBodyDynamics::Joint (
+            vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>());
+      break;
+    case 2:
+      result = RigidBodyDynamics::Joint(
+                 vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[2].get<RigidBodyDynamics::Math::SpatialVector>()
+               );
+      break;
+    case 3:
+      result = RigidBodyDynamics::Joint(
+                 vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[2].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[3].get<RigidBodyDynamics::Math::SpatialVector>()
+               );
+      break;
+    case 4:
+      result = RigidBodyDynamics::Joint(
+                 vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[2].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[3].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[4].get<RigidBodyDynamics::Math::SpatialVector>()
+               );
+      break;
+    case 5:
+      result = RigidBodyDynamics::Joint(
+                 vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[2].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[3].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[4].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[5].get<RigidBodyDynamics::Math::SpatialVector>()
+               );
+      break;
+    case 6:
+      result = RigidBodyDynamics::Joint(
+                 vector_table[1].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[2].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[3].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[4].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[5].get<RigidBodyDynamics::Math::SpatialVector>(),
+                 vector_table[6].get<RigidBodyDynamics::Math::SpatialVector>()
+               );
+      break;
+    default:
+      throw RigidBodyDynamics::Errors::RBDLFileParseError(
+            "Invalid number of DOFs for joint.");
+      break;
+    }
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+
+//==============================================================================
+template<>
+RigidBodyDynamics::Body
+LuaTableNode::getDefault<RigidBodyDynamics::Body>(
+    const RigidBodyDynamics::Body &default_value)
+{
+  RigidBodyDynamics::Body result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
+
+    double mass = 0.;
+    RigidBodyDynamics::Math::Vector3d com(
+          RigidBodyDynamics::Math::Vector3d::Zero(3));
+    RigidBodyDynamics::Math::Matrix3d inertia(
+          RigidBodyDynamics::Math::Matrix3d::Identity(3,3));
+
+    mass = vector_table["mass"];
+    com = vector_table["com"]
+        .getDefault<RigidBodyDynamics::Math::Vector3d>(com);
+    inertia = vector_table["inertia"]
+        .getDefault<RigidBodyDynamics::Math::Matrix3d>(inertia);
+
+    result = RigidBodyDynamics::Body (mass, com, inertia);
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+
+template<> Point
+LuaTableNode::getDefault<Point>(
+  const Point &default_value)
+{ 
+  Point result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable point_table = LuaTable::fromLuaState (luaTable->L);
+
+    result.name         = point_table["name"].get<std::string>();
+    result.point_local  = point_table["point"];
+    result.body_name    = point_table["body"].get<std::string>();
+  }
+
+  stackRestore();
+
+  return result;
+}
+
+//==============================================================================
+
+template<> MotionCaptureMarker
+LuaTableNode::getDefault<MotionCaptureMarker>(
+  const MotionCaptureMarker &default_value)
+{
+  MotionCaptureMarker result = default_value;
+
+  if (stackQueryValue()) {
+    LuaTable marker_table = LuaTable::fromLuaState (luaTable->L);
+
+    result.name         = marker_table["name"].get<std::string>();
+    result.point_local  = marker_table["point"];
+  }
+
+  stackRestore();
+
+  return result;
+}
+/* LUASTRUCTS_H */
+#endif

--- a/addons/luamodel/sampleconstrainedmodel.lua
+++ b/addons/luamodel/sampleconstrainedmodel.lua
@@ -78,6 +78,12 @@ meshes = {
   },
 }
 
+eye33 = {
+  {1.,0.,0.,},
+  {0.,1.,0.,},
+  {0.,0.,1.,},
+}
+
 model = {
 
   gravity = {0, 0, 0},
@@ -133,61 +139,44 @@ model = {
 
   },
 
+  --Named body fixed points. The names of the fields have been set for
+  --historical reasons. It would make more sense if this was named instead
+  -- local_points, with a field of 'r' rather than 'point'.
+  points = {
+    {name = 'base_origin', body='base', point={0.,0.,0.},},
+  },
+
+  --Named local frames
+  local_frames = {
+    {name = 'l12_A',       body='l12',  r={l2,0.,0.}, E=eye33,},
+    {name = 'l22_B',       body='l22',  r={0.,0.,0.}, E=eye33,},
+  },
+
   constraint_sets = {
     individual_constraints = {
-      {
-        constraint_type = 'contact',
-        body = 'base',
-        point = {0, 0, 0},
-        normal = {1., 0., 0.},
-        name = 'contactBaseX',
-        id = 2,
+      { -- Contact Constraint: verbose syntax
+        -- Note: Contact Constraints do not have the 'enable_stablization' flag
+        --       exposed (it is currently ignored if present) because this 
+        --       type of constraint is very well numerically behaved and rarely
+        --       suffers from drift.
+        constraint_type = 'contact', name = 'contactBaseX', id = 2,
+        body = 'base', point = {0, 0, 0}, normal = {1., 0., 0.},
       }, 
-      {
-        constraint_type = 'contact',
-        body = 'base',
-        point = {0, 0, 0},
-        normal = {0., 1., 0.},
-        name = 'contactBaseY',
-        id = 3,
+      { -- Contact Constraint: contact syntax - makes use of named points
+        -- and passes a set of normals
+        constraint_type = 'contact', name = 'contactBaseYZ', id = 3,        
+        point_name = 'base_origin', normal_sets = {{0.,1.,0.,},{0.,0.,1.}},
       }, 
-      {
-        constraint_type = 'contact',
-        body = 'base',
-        point = {0, 0, 0},
-        normal = {0., 0., 1.},
-        name = 'contactBaseZ',
-        id = 4,
-      },                  
-      {
-        constraint_type = 'loop',
-        predecessor_body = 'l12',
-        successor_body = 'l22',
-        predecessor_transform = {
-          E = {
-            {1, 0, 0},
-            {0, 1, 0},
-            {0, 0, 1},
-          },
-          r = {l2, 0, 0},
-        },
-        successor_transform = {
-          E = {
-            {1, 0, 0},
-            {0, 1, 0},
-            {0, 0, 1},
-          },
-          r = {0, 0, 0},
-        },
+      { -- Loop Constraint: compact syntax - makes use of named local_frames        
+        constraint_type = 'loop', name = 'loopL12L22Tx', id = 1, 
+        predecessor_local_frame = 'l12_A',
+        successor_local_frame = 'l22_B',
         axis =  {0., 0., 0., 1., 0., 0.},
         stabilization_coefficient = 0.1,
-        name = 'loopL12L22Tx',
-        id = 1,
       },
-      {
-        constraint_type = 'loop',
+      { -- Loop Constraint: verbose syntax.
+        constraint_type = 'loop', name = 'loopL12L22Ty', id = 2,
         predecessor_body = 'l12',
-        successor_body = 'l22',
         predecessor_transform = {
           E = {
             {1, 0, 0},
@@ -196,6 +185,7 @@ model = {
           },
           r = {l2, 0, 0},
         },
+        successor_body = 'l22',
         successor_transform = {
           E = {
             {1, 0, 0},
@@ -206,49 +196,30 @@ model = {
         },
         axis = {0., 0., 0., 0., 1., 0.},      
         stabilization_coefficient = 0.1,
-        name = 'loopL12L22Ty',
-        id = 2,
+        enable_stabilization = true,
       },      
     },
     constraints_in_sets = {
-      {
-        constraint_type = 'contact',
-        body = 'base',
-        point = {0, 0, 0},
+      { -- Contact Constraint: compact syntax - use of named points and 
+        -- normal sets
+        constraint_type = 'contact',name = 'contactBaseXYZ',id = 2,
+        point_name = 'base_origin',
         normal_sets = {{1., 0., 0.},
                        {0., 1., 0.},
-                       {0., 0., 1.},},
-        name = 'contactBaseXYZ',
-        id = 2,
+                       {0., 0., 1.},},        
       },
-      {
-        constraint_type = 'loop',
-        predecessor_body = 'l12',
-        successor_body = 'l22',
-        predecessor_transform = {
-          E = {
-            {1, 0, 0},
-            {0, 1, 0},
-            {0, 0, 1},
-          },
-          r = {l2, 0, 0},
-        },
-        successor_transform = {
-          E = {
-            {1, 0, 0},
-            {0, 1, 0},
-            {0, 0, 1},
-          },
-          r = {0, 0, 0},
-        },
+      { -- Loop Constraint: compact syntax - use of named local_frames 
+        -- and normal sets
+        constraint_type = 'loop', name = 'loopL12L22TxTy', id = 1,
+        predecessor_local_frame = 'l12_A',
+        successor_local_frame = 'l22_B',              
         axis_sets = {{0., 0., 0., 1., 0., 0.},
                      {0., 0., 0., 0., 1., 0.},},
-        stabilization_coefficient = 0.1,
-        name = 'loopL12L22TxTy',
-        id = 1,
+        stabilization_coefficient = 0.1,        
+        enable_stabilization = false,
       },
     },
-  },
+  },  
 
 }
 

--- a/addons/luamodel/samplemodel.lua
+++ b/addons/luamodel/samplemodel.lua
@@ -39,12 +39,25 @@ joints = {
 	fixed = {},
 }
 
+eye33 = {{1.0,0.0,0.,},
+	 			 {0.0,1.0,0.,},
+	 			 {0.0,0.0,1.,},}
+
+
 return {
+  --Named body fixed points. The names of the fields have been set for
+  --historical reasons. It would make more sense if this was named instead
+  -- local_points, with a field of 'r' rather than 'point'.
 points = {
 	{name = "Heel_Medial_L", 			body = "foot_right", point = {-0.080000, -0.042000, -0.091000,},},
 	{name = "Heel_Lateral_L", 		body = "foot_right", point = {-0.080000, 0.042000, -0.091000,},},
 	{name = "ForeFoot_Medial_L", 	body = "foot_right", point = {0.181788, -0.054000, -0.091000,},},
 	{name = "ForeFoot_Lateral_L", body = "foot_right", point = {0.181788, 0.054000, -0.091000,},},
+},
+--Named local frames
+local_frames = {
+  {name = "Pocket_L",   body="thigh_left",   r={0.,  0.2, 0.}, E=eye33, },
+  {name = "Pocket_R",   body="thigh_right",  r={0., -0.2, 0.}, E=eye33, },
 },
 frames = {
 	{

--- a/addons/luamodel/samplemodel.lua
+++ b/addons/luamodel/samplemodel.lua
@@ -1,7 +1,7 @@
 inertia = { 
 	{1.1, 0.1, 0.2},
 	{0.3, 1.2, 0.4},
-	{0.5, 0.6, 1.3}
+	{0.5, 0.6, 1.3},
 }
 
 pelvis = { mass = 9.3, com = { 1.1, 1.2, 1.3}, inertia = inertia }
@@ -13,8 +13,10 @@ bodies = {
 	pelvis = pelvis,
 	thigh_right = thigh,
 	shank_right = shank,
+	foot_right = foot,
 	thigh_left = thigh,
-	shank_left = shank
+	shank_left = shank,
+	foot_left = foot,
 }
 
 joints = {
@@ -24,64 +26,76 @@ joints = {
 		{ 0., 0., 0., 0., 0., 1.},
 		{ 0., 0., 1., 0., 0., 0.},
 		{ 0., 1., 0., 0., 0., 0.},
-		{ 1., 0., 0., 0., 0., 0.}
+		{ 1., 0., 0., 0., 0., 0.},
 	},
 	spherical_zyx = {
 		{ 0., 0., 1., 0., 0., 0.},
 		{ 0., 1., 0., 0., 0., 0.},
-		{ 1., 0., 0., 0., 0., 0.}
+		{ 1., 0., 0., 0., 0., 0.},
 	},
 	rotational_y = {
-		{ 0., 1., 0., 0., 0., 0.}
+		{ 0., 1., 0., 0., 0., 0.},
 	},
-	fixed = {}
+	fixed = {},
 }
 
-model = {
-	frames = {
-		{
-			name = "pelvis",
-			parent = "ROOT",
-			body = bodies.pelvis,
-			joint = joints.freeflyer,
-		},
-		{
-			name = "thigh_right",
-			parent = "pelvis",
-			body = bodies.thigh_right,
-			joint = joints.spherical_zyx,
-		},
-		{
-			name = "shank_right",
-			parent = "thigh_right",
-			body = bodies.thigh_right,
-			joint = joints.rotational_y
-		},
-		{
-			name = "foot_right",
-			parent = "shank_right",
-			body = bodies.thigh_right,
-			joint = joints.fixed
-		},
-		{
-			name = "thigh_left",
-			parent = "pelvis",
-			body = bodies.thigh_left,
-			joint = joints.spherical_zyx
-		},
-		{
-			name = "shank_left",
-			parent = "thigh_left",
-			body = bodies.thigh_left,
-			joint = joints.rotational_y
-		},
-		{
-			name = "foot_left",
-			parent = "shank_left",
-			body = bodies.thigh_left,
-			joint = joints.fixed
-		},
-	}
+return {
+points = {
+	{name = "Heel_Medial_L", 			body = "foot_right", point = {-0.080000, -0.042000, -0.091000,},},
+	{name = "Heel_Lateral_L", 		body = "foot_right", point = {-0.080000, 0.042000, -0.091000,},},
+	{name = "ForeFoot_Medial_L", 	body = "foot_right", point = {0.181788, -0.054000, -0.091000,},},
+	{name = "ForeFoot_Lateral_L", body = "foot_right", point = {0.181788, 0.054000, -0.091000,},},
+},
+frames = {
+	{
+		name = "pelvis",
+		parent = "ROOT",
+		body = bodies.pelvis,
+		joint = joints.freeflyer,
+		markers = {
+			LASI = 	{ 0.047794, 0.200000, 0.070908,},
+			RASI = 	{ 0.047794, -0.200000, 0.070908,},
+			LPSI = 	{ -0.106106, 0.200000, 0.070908,},
+			RPSI = 	{ -0.106106, -0.200000, 0.070908,},},		
+	},
+	{
+		name = "thigh_right",
+		parent = "pelvis",
+		body = bodies.thigh_right,
+		joint = joints.spherical_zyx,
+		markers = {
+			RTHI = 	{ -0.007376, -0.000000, -0.243721,},
+			RKNE = 	{ -0.011611, -0.000000, -0.454494,},},		
+	},
+	{
+		name = "shank_right",
+		parent = "thigh_right",
+		body = bodies.thigh_right,
+		joint = joints.rotational_y,	
+	},
+	{
+		name = "foot_right",
+		parent = "shank_right",
+		body = bodies.foot_right,
+		joint = joints.fixed,	
+	},
+	{
+		name = "thigh_left",
+		parent = "pelvis",
+		body = bodies.thigh_left,
+		joint = joints.spherical_zyx,
+	},
+	{
+		name = "shank_left",
+		parent = "thigh_left",
+		body = bodies.shank_left,
+		joint = joints.rotational_y,
+	},
+	{
+		name = "foot_left",
+		parent = "shank_left",
+		body = bodies.foot_left,
+		joint = joints.fixed,
+	},
+},
 }
-
-return model

--- a/addons/luamodel/tests/testLuaModel.cc
+++ b/addons/luamodel/tests/testLuaModel.cc
@@ -18,6 +18,7 @@
 #include <cstring>
 
 using namespace RigidBodyDynamics;
+using namespace RigidBodyDynamics::Math;
 using namespace RigidBodyDynamics::Addons;
 
 using namespace std;
@@ -94,6 +95,61 @@ TEST(LoadMotionCaptureMarkers)
 
 
 }
+TEST(LoadLocalFrames)
+{
+  Model model;
+  std::string modelFile = rbdlSourcePath;
+  modelFile.append("/samplemodel.lua");
+  bool modelLoaded = LuaModelReadFromFile(modelFile.c_str(), &model, false);
+  std::vector< LocalFrame > updLocalFrameSet;
+  bool localFramesLoaded = LuaModelReadLocalFrames(modelFile.c_str(),&model,
+                                                    updLocalFrameSet,false);
+
+  CHECK(updLocalFrameSet.size()==2);
+
+  unsigned int thighLeftId = model.GetBodyId("thigh_left");
+  unsigned int thighRightId = model.GetBodyId("thigh_right");
+
+  CHECK(std::strcmp("Pocket_L",updLocalFrameSet[0].name.c_str())==0);
+  CHECK(updLocalFrameSet[0].body_id == thighLeftId);
+
+  CHECK_CLOSE(updLocalFrameSet[0].r[0], 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].r[1], 0.2, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].r[2], 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[0].E(0,0), 1.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(0,1), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(0,2), 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[0].E(1,0), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(1,1), 1.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(1,2), 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[0].E(2,0), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(2,1), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[0].E(2,2), 1.0, TEST_PREC);
+
+
+  CHECK(std::strcmp("Pocket_R",updLocalFrameSet[1].name.c_str())==0);
+  CHECK(updLocalFrameSet[1].body_id == thighRightId);
+  CHECK_CLOSE(updLocalFrameSet[1].r[0], 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].r[1],-0.2, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].r[2], 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[1].E(0,0), 1.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(0,1), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(0,2), 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[1].E(1,0), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(1,1), 1.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(1,2), 0.0, TEST_PREC);
+
+  CHECK_CLOSE(updLocalFrameSet[1].E(2,0), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(2,1), 0.0, TEST_PREC);
+  CHECK_CLOSE(updLocalFrameSet[1].E(2,2), 1.0, TEST_PREC);
+
+
+}
 TEST(LoadPoints)
 {
   Model model;
@@ -155,7 +211,178 @@ TEST(LoadConstrainedLuaModel)
                                                           constraintSets,
                                                           constraintSetNames,
                                                           false);
-  CHECK(modelLoaded);    
+
+  CHECK(modelLoaded);
+
+  unsigned int baseId = model.GetBodyId("base");
+  unsigned int rootId = model.GetBodyId("ROOT");
+  unsigned int l12Id = model.GetBodyId("l12");
+  unsigned int l22Id = model.GetBodyId("l22");
+
+  unsigned int groupIndex = 0;
+
+
+  // Contact Constraint X
+  groupIndex = constraintSets[0].getGroupIndexByName("contactBaseX");
+  CHECK(constraintSets[0].getGroupSize(groupIndex) == 1);
+  CHECK(constraintSets[0].getGroupType(groupIndex) == ConstraintTypeContact);
+  unsigned int userDefinedId = constraintSets[0].getGroupId(groupIndex);
+  CHECK(userDefinedId == 2);
+
+  std::vector<unsigned int> bodyIds =
+      constraintSets[0].contactConstraints[0]->getBodyIds();
+  CHECK(bodyIds.size() == 2);
+  CHECK(bodyIds[0] == baseId);
+  CHECK(bodyIds[1] == rootId);
+
+  std::vector< Vector3d > normalVectors =
+      constraintSets[0].contactConstraints[0]->getConstraintNormalVectors();
+
+  // (all contact constraints between the same pair of bodies are grouped)
+  CHECK(normalVectors.size()==1);
+  CHECK_CLOSE(normalVectors[0][0], 1., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][1], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][2], 0., TEST_PREC);
+
+  //MM 17/5/2020
+  //Contract constraints currently do not have the Baumgarte stabilization
+  //parameter exposed: these kinds of constraints are so well numerically
+  //behaved that this kind of constraint stabilization is normally not required.
+  CHECK(constraintSets[0].isBaumgarteStabilizationEnabled(groupIndex)==false);
+
+  // Contact Constraint YZ
+  groupIndex = constraintSets[0].getGroupIndexByName("contactBaseYZ");
+  CHECK(constraintSets[0].getGroupSize(groupIndex) == 2);
+  CHECK(constraintSets[0].getGroupType(groupIndex) == ConstraintTypeContact);
+  userDefinedId = constraintSets[0].getGroupId(groupIndex);
+  CHECK(userDefinedId == 3);
+
+  normalVectors =
+        constraintSets[0].contactConstraints[1]->getConstraintNormalVectors();
+  CHECK(normalVectors.size()==2);
+
+  CHECK_CLOSE(normalVectors[0][0], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][1], 1., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][2], 0., TEST_PREC);
+
+  CHECK_CLOSE(normalVectors[1][0], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[1][1], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[1][2], 1., TEST_PREC);
+
+  //MM 17/5/2020
+  //Contract constraints currently do not have the Baumgarte stabilization
+  //parameter exposed: these kinds of constraints are so well numerically
+  //behaved that this kind of constraint stabilization is normally not required.
+  CHECK(constraintSets[0].isBaumgarteStabilizationEnabled(groupIndex) == false);
+
+  // Loop Constraint X
+  groupIndex = constraintSets[0].getGroupIndexByName("loopL12L22Tx");
+
+  CHECK(constraintSets[0].getGroupSize(groupIndex) == 1);
+  CHECK(constraintSets[0].getGroupType(groupIndex) == ConstraintTypeLoop);
+  userDefinedId = constraintSets[0].getGroupId(groupIndex);
+  CHECK(userDefinedId == 1);
+
+  bodyIds = constraintSets[0].loopConstraints[0]->getBodyIds();
+  CHECK(bodyIds.size()==2);
+  CHECK(bodyIds[0] == l12Id);
+  CHECK(bodyIds[1] == l22Id);
+
+  //Loop constraints often require stabilization so the Baumgarte
+  //stabilization parameters are exposed
+  CHECK(constraintSets[0].isBaumgarteStabilizationEnabled(groupIndex) == false);
+
+  std::vector< SpatialVector > axis =
+    constraintSets[0].loopConstraints[0]->getConstraintAxes();
+  CHECK(axis.size()==1);
+  CHECK_CLOSE( axis[0][0], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][1], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][2], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][3], 1., TEST_PREC);
+  CHECK_CLOSE( axis[0][4], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][5], 0., TEST_PREC);
+
+  // Loop Constraint Y
+  groupIndex = constraintSets[0].getGroupIndexByName("loopL12L22Ty");
+  CHECK(constraintSets[0].getGroupSize(groupIndex) == 1);
+  CHECK(constraintSets[0].getGroupType(groupIndex) == ConstraintTypeLoop);
+  userDefinedId = constraintSets[0].getGroupId(groupIndex);
+  CHECK(userDefinedId == 2);
+
+  axis =constraintSets[0].loopConstraints[1]->getConstraintAxes();
+  CHECK(axis.size()==1);
+
+  CHECK_CLOSE( axis[0][0], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][1], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][2], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][3], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][4], 1., TEST_PREC);
+  CHECK_CLOSE( axis[0][5], 0., TEST_PREC);
+
+  //Loop constraints often require stabilization so the Baumgarte
+  //stabilization parameters are exposed
+  CHECK(constraintSets[0].isBaumgarteStabilizationEnabled(groupIndex) == true);
+
+
+  // Contact Constraint XYZ
+  groupIndex = constraintSets[1].getGroupIndexByName("contactBaseXYZ");
+  CHECK(constraintSets[1].getGroupSize(groupIndex) == 3);
+  CHECK(constraintSets[1].getGroupType(groupIndex) == ConstraintTypeContact);
+  CHECK(constraintSets[1].getGroupId(groupIndex) == 2);
+
+  bodyIds = constraintSets[1].contactConstraints[0]->getBodyIds();
+  CHECK(bodyIds.size()==2);
+  CHECK(bodyIds[0] == baseId);
+  CHECK(bodyIds[1] == rootId);
+
+  normalVectors =
+      constraintSets[1].contactConstraints[0]->getConstraintNormalVectors();
+  CHECK(normalVectors.size()==3);
+  CHECK_CLOSE(normalVectors[0][0], 1., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][1], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[0][2], 0., TEST_PREC);
+
+  CHECK_CLOSE(normalVectors[1][0], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[1][1], 1., TEST_PREC);
+  CHECK_CLOSE(normalVectors[1][2], 0., TEST_PREC);
+
+  CHECK_CLOSE(normalVectors[2][0], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[2][1], 0., TEST_PREC);
+  CHECK_CLOSE(normalVectors[2][2], 1., TEST_PREC);
+
+  CHECK(constraintSets[1].isBaumgarteStabilizationEnabled(groupIndex) == false);
+
+  // Loop Constraint Tx Ty
+  groupIndex = constraintSets[1].getGroupIndexByName("loopL12L22TxTy");
+  CHECK(constraintSets[1].getGroupSize(groupIndex) == 2);
+  CHECK(constraintSets[1].getGroupType(groupIndex) == ConstraintTypeLoop);
+  CHECK(constraintSets[1].getGroupId(groupIndex) == 1);
+
+  bodyIds = constraintSets[1].loopConstraints[0]->getBodyIds();
+  CHECK(bodyIds.size()==2);
+  CHECK(bodyIds[0] == l12Id);
+  CHECK(bodyIds[1] == l22Id);
+
+  axis =
+    constraintSets[1].loopConstraints[0]->getConstraintAxes();
+  CHECK(axis.size()==2);
+  CHECK_CLOSE( axis[0][0], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][1], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][2], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][3], 1., TEST_PREC);
+  CHECK_CLOSE( axis[0][4], 0., TEST_PREC);
+  CHECK_CLOSE( axis[0][5], 0., TEST_PREC);
+
+  CHECK_CLOSE( axis[1][0], 0., TEST_PREC);
+  CHECK_CLOSE( axis[1][1], 0., TEST_PREC);
+  CHECK_CLOSE( axis[1][2], 0., TEST_PREC);
+  CHECK_CLOSE( axis[1][3], 0., TEST_PREC);
+  CHECK_CLOSE( axis[1][4], 1., TEST_PREC);
+  CHECK_CLOSE( axis[1][5], 0., TEST_PREC);
+
+  CHECK(constraintSets[1].isBaumgarteStabilizationEnabled(groupIndex) == false);
+
+
 }
 
 int main (int argc, char *argv[])

--- a/addons/luamodel/tests/testLuaModel.cc
+++ b/addons/luamodel/tests/testLuaModel.cc
@@ -15,12 +15,14 @@
 #include <rbdl/rbdl.h>
 #include <string>
 #include <vector>
-
+#include <cstring>
 
 using namespace RigidBodyDynamics;
 using namespace RigidBodyDynamics::Addons;
 
 using namespace std;
+
+const double TEST_PREC = 1.0e-11;
 
 std::string rbdlSourcePath;
    
@@ -31,6 +33,105 @@ TEST(LoadLuaModel)
   modelFile.append("/samplemodel.lua");
   bool modelLoaded = LuaModelReadFromFile(modelFile.c_str(), &model, false);
   CHECK(modelLoaded);
+}
+TEST(LoadMotionCaptureMarkers)
+{
+  Model model;
+  std::string modelFile = rbdlSourcePath;
+  modelFile.append("/samplemodel.lua");
+  bool modelLoaded = LuaModelReadFromFile(modelFile.c_str(), &model, false);
+  std::vector< Point > updMarkerSet;
+  bool markersLoaded = LuaModelReadMotionCaptureMarkers(modelFile.c_str(),
+                                               &model, updMarkerSet,false);
+  CHECK(updMarkerSet.size()==6);
+  //The markers come out of order which makes testing a bit tricky.
+  for(unsigned int i=0; i<updMarkerSet.size(); ++i){
+    bool flag_found = false;
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"LASI")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("pelvis"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0], 0.047794,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1], 0.200000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2], 0.070908,TEST_PREC);
+      flag_found = true;
+    }
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"RASI")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("pelvis"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0], 0.047794,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1],-0.200000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2], 0.070908,TEST_PREC);
+      flag_found = true;
+    }
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"LPSI")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("pelvis"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0],-0.106106,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1], 0.200000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2], 0.070908,TEST_PREC);
+      flag_found = true;
+    }
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"RPSI")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("pelvis"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0],-0.106106,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1],-0.200000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2], 0.070908,TEST_PREC);
+      flag_found = true;
+    }
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"RTHI")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("thigh_right"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0],-0.007376,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1], 0.000000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2],-0.243721,TEST_PREC);
+      flag_found = true;
+    }
+    if(std::strcmp(updMarkerSet[i].name.c_str(),"RKNE")==0){
+      CHECK( updMarkerSet[i].body_id == model.GetBodyId("thigh_right"));
+      CHECK_CLOSE(updMarkerSet[i].point_local[0],-0.011611,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[1], 0.000000,TEST_PREC);
+      CHECK_CLOSE(updMarkerSet[i].point_local[2],-0.454494,TEST_PREC);
+      flag_found = true;
+    }
+    CHECK(flag_found);
+  }
+
+
+}
+TEST(LoadPoints)
+{
+  Model model;
+  std::string modelFile = rbdlSourcePath;
+  modelFile.append("/samplemodel.lua");
+  bool modelLoaded = LuaModelReadFromFile(modelFile.c_str(), &model, false);
+  std::vector< Point > updPointSet;
+  bool pointsLoaded = LuaModelReadPoints(modelFile.c_str(),&model,
+                                         updPointSet,false);
+  CHECK(updPointSet.size()==4);
+  
+  unsigned int bodyId = model.GetBodyId("foot_right");
+
+  CHECK( strcmp( updPointSet[0].name.c_str(),"Heel_Medial_L")      == 0);
+  CHECK( strcmp( updPointSet[1].name.c_str(),"Heel_Lateral_L")     == 0);
+  CHECK( strcmp( updPointSet[2].name.c_str(),"ForeFoot_Medial_L")  == 0);
+  CHECK( strcmp( updPointSet[3].name.c_str(),"ForeFoot_Lateral_L") == 0);
+
+  CHECK( updPointSet[0].body_id == bodyId );
+  CHECK( updPointSet[1].body_id == bodyId );
+  CHECK( updPointSet[2].body_id == bodyId );
+  CHECK( updPointSet[3].body_id == bodyId );
+
+  CHECK_CLOSE(updPointSet[0].point_local[0], -0.080, TEST_PREC);
+  CHECK_CLOSE(updPointSet[0].point_local[1], -0.042, TEST_PREC);
+  CHECK_CLOSE(updPointSet[0].point_local[2], -0.091, TEST_PREC);
+
+  CHECK_CLOSE(updPointSet[1].point_local[0], -0.080, TEST_PREC);
+  CHECK_CLOSE(updPointSet[1].point_local[1],  0.042, TEST_PREC);
+  CHECK_CLOSE(updPointSet[1].point_local[2], -0.091, TEST_PREC);
+  
+  CHECK_CLOSE(updPointSet[2].point_local[0],  0.181788, TEST_PREC);
+  CHECK_CLOSE(updPointSet[2].point_local[1], -0.054000, TEST_PREC);
+  CHECK_CLOSE(updPointSet[2].point_local[2], -0.091000, TEST_PREC);
+
+  CHECK_CLOSE(updPointSet[3].point_local[0],  0.181788, TEST_PREC);
+  CHECK_CLOSE(updPointSet[3].point_local[1],  0.054000, TEST_PREC);
+  CHECK_CLOSE(updPointSet[3].point_local[2], -0.091000, TEST_PREC);
 }
 
 TEST(LoadConstrainedLuaModel)

--- a/include/rbdl/Constraints.h
+++ b/include/rbdl/Constraints.h
@@ -719,6 +719,7 @@ struct RBDL_DLLAPI ConstraintSet {
     const char *constraintName = NULL,
     unsigned int userDefinedId = std::numeric_limits<unsigned int>::max());
 
+
   /** \brief Adds a loop constraint to the constraint set.
    
     This type of constraints ensures that the relative orientation and position,

--- a/src/Constraints.cc
+++ b/src/Constraints.cc
@@ -76,7 +76,9 @@ unsigned int ConstraintSet::AddContactConstraint (
     if(contactConstraints[i]->getBodyIds()[0] == body_id) {
       Vector3d pointErr = body_point -
                           contactConstraints[i]->getBodyFrames()[0].r;
-      if(pointErr.norm() < std::numeric_limits<double>::epsilon()*100) {
+
+      if(pointErr.norm() < std::numeric_limits<double>::epsilon()*100
+         && contactConstraints[i]->getUserDefinedId() == userDefinedId) {
         constraintAppended = true;
         contactConstraints[i]->appendNormalVector(world_normal);
       }
@@ -209,7 +211,8 @@ unsigned int ConstraintSet::AddLoopConstraint (
         }
       }
 
-      if(framesNumericallyIdentical) {
+      if(framesNumericallyIdentical
+         && loopConstraints[idx]->getUserDefinedId() == userDefinedId) {
         constraintAppended = true;
         loopConstraints[idx]->appendConstraintAxis(constraintAxisInPredecessor);
       }


### PR DESCRIPTION
1. New structures and functions added to luamodel

- Point & LuaModelReadPoints
- LocalFrame & LuaModelReadLocalFrames
- MotionCaptureMarker & LuaModelReadMotionCaptureMarkers

2. The function LuaModelReadFromFileWithConstraints has been updated so that Contact and Loop constraints can take advantage of a more compact syntax by using the 'point' and 'local_frame' sets.

3. The test code in addons/luamodel/tests/testLuaModel.cc has been greatly expanded: the read in model is compared against the known values for almost every exposed field. The only field currently missing from the test is the local transform between a body and the point at which a Contact/Loop constraints are applied.

4. A small tweak has been made to AddContactConstraint and AddLoopConstraint: subsequent constraints are put in the same group now if they are the same type, apply to the same bodies and local points, and have the same user defined ids.

5. The sample lua models have been commented a bit. Between reading the doxygen in Constraints.h and the lua comments an end user of RBDL should be able to figure out what's going on.