### PR TITLE
Expose SetActuationMap in Python Bindings

### DIFF
--- a/python/crbdl.pxd
+++ b/python/crbdl.pxd
@@ -626,6 +626,25 @@ cdef extern from "rbdl_ptr_functions.h" namespace "RigidBodyDynamics":
             vector[SpatialVector] *f_ext
             )
 
+    cdef void InverseDynamicsConstraintsRelaxedPtr(
+            Model &model,
+            const double* q_ptr,
+            const double* qdot_ptr,
+            const double* qddot_ptr,
+            ConstraintSet &CS,
+            double* qddot_out_ptr,
+            double* tau_ptr,
+            vector[SpatialVector] *f_ext
+            )
+
+    cdef bool isConstrainedSystemFullyActuated(
+            Model &model,
+            const double* q_ptr,
+            const double* qdot_ptr,
+            ConstraintSet &CS,
+            vector[SpatialVector] *f_ext
+            )
+
     cdef void NonlinearEffectsPtr (
             Model &model,
             const double* q_ptr,

--- a/python/crbdl.pxd
+++ b/python/crbdl.pxd
@@ -615,6 +615,17 @@ cdef extern from "rbdl_ptr_functions.h" namespace "RigidBodyDynamics":
             vector[SpatialVector] *f_ext
             )
 
+    cdef void InverseDynamicsConstraintsPtr(
+            Model &model,
+            const double* q_ptr,
+            const double* qdot_ptr,
+            const double* qddot_ptr,
+            ConstraintSet &CS,
+            double* qddot_out_ptr,
+            double* tau_ptr,
+            vector[SpatialVector] *f_ext
+            )
+
     cdef void NonlinearEffectsPtr (
             Model &model,
             const double* q_ptr,

--- a/python/crbdl.pxd
+++ b/python/crbdl.pxd
@@ -533,6 +533,9 @@ cdef extern from "<rbdl/Constraints.h>" namespace "RigidBodyDynamics":
         # void SetSolver (Math::LinearSolver solver)
         bool Bind (const Model &model)
 
+        void SetActuationMap(const Model& model,
+                const vector[bool]& actuatedDof);
+
         size_t size()
         void clear()
         # Math::LinearSolver

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -1825,6 +1825,21 @@ cdef class ConstraintSet:
     def Bind (self, model):
         return self.thisptr.Bind ((<Model>model).thisptr[0])
 
+    def SetActuationMap(self,
+            Model model,
+            np.ndarray[bool, ndim=1, mode="c"] actuated_dof_upd):
+
+        # Populate the actuation map.
+        cdef vector[bool] actuationMap
+        for i in range(0, actuated_dof_upd.shape[0]):
+            actuationMap.push_back(<bool> actuated_dof_upd[i])
+
+        # Set the actuation map.
+        self.thisptr.SetActuationMap(
+                model.thisptr[0],
+                actuationMap
+                )
+
     def size (self):
         return self.thisptr.size()
 

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -2485,6 +2485,47 @@ def InverseDynamics (Model model,
             )
             
     del f_ext
+
+def InverseDynamicsConstraints (Model model,
+        np.ndarray[double, ndim=1, mode="c"] q,
+        np.ndarray[double, ndim=1, mode="c"] qdot,
+        np.ndarray[double, ndim=1, mode="c"] qddot,
+        ConstraintSet CS,
+        np.ndarray[double, ndim=1, mode="c"] qddot_out,
+        np.ndarray[double, ndim=1, mode="c"] tau,
+        np.ndarray[double, ndim=2, mode="c"] f_external = None):
+      
+    cdef vector[crbdl.SpatialVector] *f_ext = new vector[crbdl.SpatialVector]()
+    
+    if f_external is None:
+        
+        crbdl.InverseDynamicsConstraintsPtr (model.thisptr[0],
+            <double*>q.data,
+            <double*>qdot.data,
+            <double*>qddot.data,
+            CS.thisptr[0],
+            <double*>qddot_out.data,
+            <double*>tau.data,
+            NULL
+            )
+        
+    else:
+         
+        for ele in f_external: 
+            f_ext.push_back(NumpyToSpatialVector(ele))
+            
+        crbdl.InverseDynamicsConstraintsPtr (model.thisptr[0],
+            <double*>q.data,
+            <double*>qdot.data,
+            <double*>qddot.data,
+            CS.thisptr[0],
+            <double*>qddot_out.data,
+            <double*>tau.data,
+            f_ext
+            )
+            
+    del f_ext
+
             
 
 def NonlinearEffects (Model model,

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -2526,6 +2526,76 @@ def InverseDynamicsConstraints (Model model,
             
     del f_ext
 
+def InverseDynamicsConstraintsRelaxed (Model model,
+        np.ndarray[double, ndim=1, mode="c"] q,
+        np.ndarray[double, ndim=1, mode="c"] qdot,
+        np.ndarray[double, ndim=1, mode="c"] qddot,
+        ConstraintSet CS,
+        np.ndarray[double, ndim=1, mode="c"] qddot_out,
+        np.ndarray[double, ndim=1, mode="c"] tau,
+        np.ndarray[double, ndim=2, mode="c"] f_external = None):
+      
+    cdef vector[crbdl.SpatialVector] *f_ext = new vector[crbdl.SpatialVector]()
+    
+    if f_external is None:
+        
+        crbdl.InverseDynamicsConstraintsRelaxedPtr (model.thisptr[0],
+            <double*>q.data,
+            <double*>qdot.data,
+            <double*>qddot.data,
+            CS.thisptr[0],
+            <double*>qddot_out.data,
+            <double*>tau.data,
+            NULL
+            )
+        
+    else:
+         
+        for ele in f_external: 
+            f_ext.push_back(NumpyToSpatialVector(ele))
+            
+        crbdl.InverseDynamicsConstraintsRelaxedPtr (model.thisptr[0],
+            <double*>q.data,
+            <double*>qdot.data,
+            <double*>qddot.data,
+            CS.thisptr[0],
+            <double*>qddot_out.data,
+            <double*>tau.data,
+            f_ext
+            )
+            
+    del f_ext
+
+
+def isConstrainedSystemFullyActuated(Model model,
+    np.ndarray[double, ndim=1, mode="c"] q,
+    np.ndarray[double, ndim=1, mode="c"] qdot,
+    ConstraintSet CS,
+    np.ndarray[double, ndim=2, mode="c"] f_external = None):
+
+    cdef vector[crbdl.SpatialVector] *f_ext = new vector[crbdl.SpatialVector]()
+
+    if f_external is None:
+        v = crbdl.isConstrainedSystemFullyActuated(model.thisptr[0],
+                <double*>q.data,
+                <double*>qdot.data,
+                CS.thisptr[0],
+                NULL
+                )
+    else:
+        for ele in f_external: 
+            f_ext.push_back(NumpyToSpatialVector(ele))
+
+        v = crbdl.isConstrainedSystemFullyActuated(model.thisptr[0],
+                <double*>q.data,
+                <double*>qdot.data,
+                CS.thisptr[0],
+                f_ext
+                )
+
+    del f_ext
+
+    return v
             
 
 def NonlinearEffects (Model model,

--- a/python/rbdl_ptr_functions.h
+++ b/python/rbdl_ptr_functions.h
@@ -408,9 +408,9 @@ void InverseDynamicsPtr (
 
 
   VectorNdRef Q = VectorFromPtr(const_cast<double*>(q_ptr), model.q_size);
-  VectorNdRef QDot = VectorFromPtr(const_cast<double*>(qdot_ptr), model.q_size);
-  VectorNdRef QDDot = VectorFromPtr(const_cast<double*>(qddot_ptr), model.q_size);
-  VectorNdRef Tau = VectorFromPtr(const_cast<double*>(tau_ptr), model.q_size);
+  VectorNdRef QDot = VectorFromPtr(const_cast<double*>(qdot_ptr), model.qdot_size);
+  VectorNdRef QDDot = VectorFromPtr(const_cast<double*>(qddot_ptr), model.qdot_size);
+  VectorNdRef Tau = VectorFromPtr(const_cast<double*>(tau_ptr), model.qdot_size);
 
   // Reset the velocity of the root body
   model.v[0].setZero();
@@ -485,6 +485,120 @@ void InverseDynamicsPtr (
                                  model.X_lambda[i].applyTranspose(model.f[i]);
     }
   }
+}
+
+// FIXME(yycho0108): {Matrix,Vector}NdRef conversions will fail.
+// Consider other options for specifying the correct function signature.
+void SolveLinearSystem (
+        const RigidBodyDynamics::Math::MatrixNd& A,
+        const RigidBodyDynamics::Math::VectorNd& b,
+        RigidBodyDynamics::Math::VectorNd& x,
+        RigidBodyDynamics::Math::LinearSolver ls
+        )
+{
+    if(A.rows() != b.size() || A.cols() != x.size()) {
+        throw Errors::RBDLSizeMismatchError("Mismatching sizes.\n");
+    }
+
+    // Solve the system A*x = b.
+    switch (ls) {
+        case RigidBodyDynamics::Math::LinearSolverPartialPivLU :
+            x = A.partialPivLu().solve(b);
+            break;
+        case RigidBodyDynamics::Math::LinearSolverColPivHouseholderQR :
+            x = A.colPivHouseholderQr().solve(b);
+            break;
+        case RigidBodyDynamics::Math::LinearSolverHouseholderQR :
+            x = A.householderQr().solve(b);
+            break;
+        default:
+            std::ostringstream errormsg;
+            errormsg << "Error: Invalid linear solver: " << ls << std::endl;
+            throw Errors::RBDLError(errormsg.str());
+            break;
+    }
+}
+
+RBDL_DLLAPI
+void InverseDynamicsConstraintsPtr (
+  Model &model,
+  const double *q_ptr,
+  const double *qdot_ptr,
+  const double *qddot_ptr,
+  ConstraintSet &CS,
+  const double *qddot_out_ptr,
+  const double *tau_ptr,
+  std::vector<Math::SpatialVector> *f_ext
+)
+{
+  LOG << "-------- " << __func__ << " ------" << std::endl;
+
+  using namespace RigidBodyDynamics::Math;
+
+  unsigned int n  = unsigned(    CS.H.rows());
+  unsigned int nc = unsigned( CS.name.size());
+  unsigned int na = unsigned(    CS.S.rows());
+  unsigned int nu = n-na;
+
+  VectorNdRef Q = VectorFromPtr(const_cast<double*>(q_ptr), model.q_size);
+  VectorNdRef QDot = VectorFromPtr(const_cast<double*>(qdot_ptr), model.qdot_size);
+  VectorNdRef QDDotDesired = VectorFromPtr(const_cast<double*>(qddot_ptr), model.qdot_size);
+  VectorNdRef QDDotOutput = VectorFromPtr(const_cast<double*>(qddot_out_ptr), model.qdot_size);
+  VectorNdRef TauOutput = VectorFromPtr(const_cast<double*>(tau_ptr), model.qdot_size);
+
+  TauOutput.setZero();
+  CalcConstrainedSystemVariables(model,Q,QDot,TauOutput,CS,f_ext);
+
+  // This implementation follows the projected KKT system described in
+  // Eqn. 5.20 of Henning Koch's thesis work. Note that this will fail
+  // for under actuated systems
+  //  [ SMS'      SMP'    SJ'    I][      u]   [ -SC    ]
+  //  [ PMS'      PMP'    PJ'     ][      v] = [ -PC    ]
+  //  [ JS'        JP'     0      ][-lambda]   [ -gamma ]
+  //  [ I                         ][   -tau]   [  v*     ]
+  //double alpha = 0.1;
+
+  CS.Ful = CS.S*CS.H*CS.S.transpose();
+  CS.Fur = CS.S*CS.H*CS.P.transpose();
+  CS.Fll = CS.P*CS.H*CS.S.transpose();
+  CS.Flr = CS.P*CS.H*CS.P.transpose();
+
+  CS.GTu = CS.S*(CS.G.transpose());
+  CS.GTl = CS.P*(CS.G.transpose());
+
+  //Exploiting the block triangular structure
+  //u:
+  //I u = S*qdd*
+  CS.u = CS.S*QDDotDesired;
+  // v
+  //(JP')v = -gamma - (JS')u
+  //Using GT
+
+  //This fails using SimpleMath and I'm not sure how to fix it
+  SolveLinearSystem( CS.GTl.transpose(),
+                     CS.gamma - CS.GTu.transpose()*CS.u,
+                     CS.v, CS.linear_solver);
+
+  // lambda
+  SolveLinearSystem(CS.GTl,
+                    -CS.P*CS.C
+                    - CS.Fll*CS.u
+                    - CS.Flr*CS.v,
+                    CS.force,
+                    CS.linear_solver);
+
+  for(unsigned int i=0; i<CS.force.rows(); ++i) {
+    CS.force[i] *= -1.0;
+  }
+
+  //Evaluating qdd
+  QDDotOutput = CS.S.transpose()*CS.u + CS.P.transpose()*CS.v;
+
+  //Evaluating tau
+  TauOutput = -CS.S.transpose()*( -CS.S*CS.C
+                                  -( CS.Ful*CS.u
+                                     +CS.Fur*CS.v
+                                     -CS.GTu*CS.force));
 }
 
 

--- a/python/rbdl_ptr_functions.h
+++ b/python/rbdl_ptr_functions.h
@@ -601,6 +601,180 @@ void InverseDynamicsConstraintsPtr (
                                      -CS.GTu*CS.force));
 }
 
+RBDL_DLLAPI
+void InverseDynamicsConstraintsRelaxedPtr(
+  Model &model,
+  const double *q_ptr,
+  const double *qdot_ptr,
+  const double *qddot_ptr,
+  ConstraintSet &CS,
+  const double *qddot_out_ptr,
+  const double *tau_ptr,
+  std::vector<Math::SpatialVector> *f_ext)
+{
+  LOG << "-------- " << __func__ << " --------" << std::endl;
+
+  using namespace RigidBodyDynamics::Math;
+  VectorNdRef Q = VectorFromPtr(const_cast<double*>(q_ptr), model.q_size);
+  VectorNdRef QDot = VectorFromPtr(const_cast<double*>(qdot_ptr), model.qdot_size);
+  VectorNdRef QDDotControls = VectorFromPtr(const_cast<double*>(qddot_ptr), model.qdot_size);
+  VectorNdRef QDDotOutput = VectorFromPtr(const_cast<double*>(qddot_out_ptr), model.qdot_size);
+  VectorNdRef TauOutput = VectorFromPtr(const_cast<double*>(tau_ptr), model.qdot_size);
+
+  TauOutput.setZero();
+  CalcConstrainedSystemVariables(model,Q,QDot,TauOutput,CS,f_ext);
+
+  unsigned int n  = unsigned(    CS.H.rows());
+  unsigned int nc = unsigned( CS.name.size());
+  unsigned int na = unsigned(    CS.S.rows());
+  unsigned int nu = n-na;
+
+
+  //MM: Update to Henning's formulation s.t. the relaxed IDC operator will
+  //    more closely satisfy QDDotControls if it is possible.
+  double diag = 0.;//100.*CS.H.maxCoeff();
+  double diagInv = 0.;
+  for(unsigned int i=0; i<CS.H.rows(); ++i) {
+    for(unsigned int j=0; j<CS.H.cols(); ++j) {
+      if(fabs(CS.H(i,j)) > diag) {
+        diag = fabs(CS.H(i,j));
+      }
+    }
+  }
+  diag = diag*100.;
+  diagInv = 1.0/diag;
+  for(unsigned int i=0; i<CS.W.rows(); ++i) {
+    CS.W(i,i)    = diag;
+    CS.Winv(i,i) = diagInv;
+  }
+
+  CS.WinvSC = CS.Winv * CS.S * CS.C;
+
+  CS.F.block(  0,  0, na, na) = CS.S*CS.H*CS.S.transpose() + CS.W;
+  CS.F.block(  0, na, na, nu) = CS.S*CS.H*CS.P.transpose();
+  CS.F.block( na,  0, nu, na) = CS.P*CS.H*CS.S.transpose();
+  CS.F.block( na, na, nu, nu) = CS.P*CS.H*CS.P.transpose();
+
+  CS.GT.block(  0, 0,na, nc) = CS.S*(CS.G.transpose());
+  CS.GT.block( na, 0,nu, nc) = CS.P*(CS.G.transpose());
+
+  CS.GT_qr.compute (CS.GT);
+  CS.GT_qr.householderQ().evalTo (CS.GT_qr_Q);
+
+  //GT = [Y  Z] * [ R ]
+  //              [ 0 ]
+
+  CS.R  = CS.GT_qr_Q.transpose()*CS.GT;
+  CS.Ru = CS.R.block(0,0,nc,nc);
+
+  CS.Y = CS.GT_qr_Q.block( 0, 0,  n, nc    );
+  CS.Z = CS.GT_qr_Q.block( 0, nc, n, (n-nc));
+
+  //MM: Update to Henning's formulation s.t. the relaxed IDC operator will
+  //    exactly satisfy QDDotControls if it is possible.
+  //
+  //Modify QDDotControls so that SN is cancelled.
+  //
+  //    +SC - WS(qdd*)
+  //
+  // Add a term to cancel off SN
+  //
+  //    +SC - WS( qdd* + (S' W^-1 S)N )
+  //
+
+  CS.u = CS.S*CS.C - CS.W*(CS.S*(QDDotControls
+                                 +(CS.S.transpose()*CS.WinvSC)));
+
+  CS.v =  CS.P*CS.C;
+
+  for(unsigned int i=0; i<CS.S.rows(); ++i) {
+    CS.g[i] = CS.u[i];
+  }
+  unsigned int j=CS.S.rows();
+  for(unsigned int i=0; i<CS.P.rows(); ++i) {
+    CS.g[j] = CS.v[i];
+    ++j;
+  }
+
+  //nc x nc system
+  SolveLinearSystem(CS.Ru.transpose(), CS.gamma, CS.py, CS.linear_solver);
+
+  //(n-nc) x (n-nc) system
+  SolveLinearSystem(CS.Z.transpose()*CS.F*CS.Z,
+                    CS.Z.transpose()*(-CS.F*CS.Y*CS.py-CS.g),
+                    CS.pz,
+                    CS.linear_solver);
+
+  //nc x nc system
+  SolveLinearSystem(CS.Ru,
+                    CS.Y.transpose()*(CS.g + CS.F*CS.Y*CS.py + CS.F*CS.Z*CS.pz),
+                    CS.force, CS.linear_solver);
+
+  //Eqn. 32d, the equation for qdd, is in error. Instead
+  // p = Ypy + Zpz = [v,w]
+  // qdd = S'v + P'w
+  QDDotOutput = CS.Y*CS.py + CS.Z*CS.pz;
+  for(unsigned int i=0; i<CS.S.rows(); ++i) {
+    CS.u[i] = QDDotOutput[i];
+  }
+  j = CS.S.rows();
+  for(unsigned int i=0; i<CS.P.rows(); ++i) {
+    CS.v[i] = QDDotOutput[j];
+    ++j;
+  }
+
+  QDDotOutput = CS.S.transpose()*CS.u
+                +CS.P.transpose()*CS.v;
+
+  TauOutput = (CS.S.transpose()*CS.W*CS.S)*(
+                QDDotControls+(CS.S.transpose()*CS.WinvSC)
+                -QDDotOutput);
+
+
+
+}
+
+RBDL_DLLAPI
+bool isConstrainedSystemFullyActuated (
+        Model &model,
+        const double* q_ptr,
+        const double* qdot_ptr,
+        ConstraintSet& CS,
+        std::vector<Math::SpatialVector> *f_ext){
+  LOG << "-------- " << __func__ << " ------" << std::endl;
+
+  using namespace RigidBodyDynamics::Math;
+
+  unsigned int n  = unsigned(    CS.H.rows());
+  unsigned int nc = unsigned( CS.name.size());
+  unsigned int na = unsigned(    CS.S.rows());
+  unsigned int nu = n-na;
+
+  VectorNdRef Q = VectorFromPtr(const_cast<double*>(q_ptr), model.q_size);
+  VectorNdRef QDot = VectorFromPtr(const_cast<double*>(qdot_ptr), model.qdot_size);
+
+  CalcConstrainedSystemVariables(model,Q,QDot,VectorNd::Zero(QDot.rows()),CS,
+                                 f_ext);
+
+  CS.GPT = CS.G*CS.P.transpose();
+
+  CS.GPT_full_qr.compute(CS.GPT);
+  unsigned int r = unsigned(CS.GPT_full_qr.rank());
+
+  bool isCompatible = false;
+  if(r == (n-na)) {
+    isCompatible = true;
+  } else {
+    isCompatible = false;
+  }
+
+  return isCompatible;
+
+}
+
+
+
+
 
 
 RBDL_DLLAPI


### PR DESCRIPTION
Thank you for adding `SetActuationMap`, I have found it to be a great resource for solving inverse dynamics for systems for which not all joints can be actuated.
I had been primarily experimenting with the python bindings, and I think it is quite useful to expose this function to python. Upon (albeit limited) testing, it seems to work.
Based on my cursory understanding, I have modified the two files that appear to glue the C++ functions to the python API.
I think this is a fairly simple/straightforward addition, but let me know if there was any error in the additions.

**EDIT:**
While the simple binding itself probably works (i.e. interface is compatible), I realized I didn't zero out the non-actuated terms for `tau` when computing forward dynamics, which gave me the impression it was working well. Upon correction, `qddot` computed by `rbdl.ForwardDynamicsConstraintDirect` doesn't appear to actually follow the target specified in `rbdl.InverseDynamics`.)

To this end, I realized that `rbdl.InverseDynamicsConstraints` must also be wrapped for `SetActuationMap` to be meaningful. This involves a bit more modifications, but hopefully there wasn't any error in the process.

I'm still debugging my specific use-case, however, as the inverse dynamics doesn't appear to quite work.