### PR TITLE
Python wrapper

### DIFF
--- a/python/crbdl.pxd
+++ b/python/crbdl.pxd
@@ -634,39 +634,39 @@ cdef extern from "rbdl_ptr_functions.h" namespace "RigidBodyDynamics":
             )
     
     cdef bool InverseKinematicsPtr (
-						Model &model,
-						const double *qinit_ptr,
-						const vector[unsigned int] body_id,
-						const vector[Vector3d] body_point,
-						const vector[Vector3d] target_pos,
-						const double *qres_ptr,
-						double step_tol,
-						double lambda_,
-						unsigned int max_iter
-						)
+            Model &model,
+            const double *qinit_ptr,
+            const vector[unsigned int] body_id,
+            const vector[Vector3d] body_point,
+            const vector[Vector3d] target_pos,
+            const double *qres_ptr,
+            double step_tol,
+            double lambda_,
+            unsigned int max_iter
+            )
     
     cdef bool InverseKinematicsCSPtr (
-        Model &model,
-        const double *qinit_ptr,
-        InverseKinematicsConstraintSet &CS,
-        const double *qres_ptr)  
+           Model &model,
+           const double *qinit_ptr,
+           InverseKinematicsConstraintSet &CS,
+           const double *qres_ptr)  
     
     cdef void ForwardDynamicsConstraintsDirectPtr (
-        Model &model,
-        const double* q_ptr,
-        const double* qdot_ptr,
-        const double* tau_ptr,
-        ConstraintSet &CS,
-        double* qddot_ptr,
-        vector[SpatialVector] *f_ext
-        )
+           Model &model,
+           const double* q_ptr,
+           const double* qdot_ptr,
+           const double* tau_ptr,
+           ConstraintSet &CS,
+           double* qddot_ptr,
+           vector[SpatialVector] *f_ext
+           )
 
 cdef extern from "rbdl_loadmodel.cc":
     cdef bool rbdl_loadmodel (
-            const char* filename,
-            Model* model,
-            bool floating_base,
-            bool verbose)
+           const char* filename,
+           Model* model,
+           bool floating_base,
+           bool verbose)
      
         
         

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -1068,7 +1068,7 @@ cdef class Joint:
 
     property mJointType:
         def __get__ (self):
-            for key, joint in self.joint_type_map.iteritems():
+            for key, joint in self.joint_type_map.items():
                 if joint == self.thisptr.mJointType:
                     return key
         
@@ -1961,30 +1961,30 @@ def InverseKinematics (Model model,
           
   cdef vector[unsigned int] body_id
   cdef vector[crbdl.Vector3d] body_point
-  cdef vector[crbdl.Vector3d] target_pos	
+  cdef vector[crbdl.Vector3d] target_pos    
   cdef crbdl.Vector3d buf
   
-	
+    
   for i in range( body_ids.shape[0]):
-    body_id.push_back(<unsigned int> body_ids[i])		
+    body_id.push_back(<unsigned int> body_ids[i])        
   for i in range( body_point_position.shape[0]):
     buf = NumpyToVector3d(body_point_position[i])
-    body_point.push_back(buf)		
+    body_point.push_back(buf)        
   for i in range( target_pos_position.shape[0]):
     buf = NumpyToVector3d(target_pos_position[i])
-    target_pos.push_back(buf)						
+    target_pos.push_back(buf)                        
   
   return crbdl.InverseKinematicsPtr (model.thisptr[0],
-						<double*> qinit.data,
-						body_id,
-						body_point,
-						target_pos,
-						<double*> qres.data,
-						<double> step_tol,
-						<double> lambda_,
-						<unsigned int> max_iter
-						)
-						
+                        <double*> qinit.data,
+                        body_id,
+                        body_point,
+                        target_pos,
+                        <double*> qres.data,
+                        <double> step_tol,
+                        <double> lambda_,
+                        <unsigned int> max_iter
+                        )
+                        
 
 class ConstraintType(IntEnum):
     ConstraintTypePosition = 0
@@ -2027,7 +2027,7 @@ cdef class InverseKinematicsConstraintSet:
                 body_id,
                 NumpyToVector3d(body_point),
                 NumpyToVector3d(target_pos),
-				weight
+                weight
                 )
     
     def AddPointConstraintXY (self,
@@ -2092,8 +2092,8 @@ cdef class InverseKinematicsConstraintSet:
             NumpyToVector3d(body_point),
             NumpyToVector3d(target_pos),
             NumpyToMatrix3d(target_orientation),
-			weight
-			)
+            weight
+            )
 
     def ClearConstraints (self):
         return self.thisptr.ClearConstraints()
@@ -2226,14 +2226,14 @@ def InverseKinematicsCS (Model model,
     np.ndarray[double, ndim=1, mode="c"] qinit, 
     InverseKinematicsConstraintSet CS,
     np.ndarray[double, ndim=1, mode="c"] qres):
-          					
+                              
   
     return crbdl.InverseKinematicsCSPtr (model.thisptr[0],
         <double*> qinit.data,
-				CS.thisptr[0],
-				<double*> qres.data,
-				)
-						
+                CS.thisptr[0],
+                <double*> qres.data,
+                )
+                        
 
        
 

--- a/python/rbdl-wrapper.pyx
+++ b/python/rbdl-wrapper.pyx
@@ -1068,8 +1068,10 @@ cdef class Joint:
 
     property mJointType:
         def __get__ (self):
-            return self.joint_type_map[self.thisptr.mJointType]
-
+            for key, joint in self.joint_type_map.iteritems():
+                if joint == self.thisptr.mJointType:
+                    return key
+        
 # was NOT WRITABLE originally - had to be changed because of CustomJoint
     property q_index:
         def __get__ (self):
@@ -1520,15 +1522,12 @@ cdef class Model:
 
 cdef class ConstraintSet
 
-%VectorWrapperClassDefinitions(PARENT=ConstraintSet)%
 
 cdef class ConstraintSet:
     cdef crbdl.ConstraintSet *thisptr
-    %VectorWrapperMemberDefinitions (PARENT=ConstraintSet)%
 
     def __cinit__(self):
         self.thisptr = new crbdl.ConstraintSet()
-        %VectorWrapperCInitCode (PARENT=ConstraintSet)%
 
     def __dealloc__(self):
         del self.thisptr
@@ -1760,17 +1759,6 @@ cdef class ConstraintSet:
         def __get__ (self):
             return self.thisptr.bound
 
-#    %VectorWrapperAddProperty (TYPE=string, MEMBER=name, PARENT=ConstraintSet)%
-
-#    %VectorWrapperAddProperty (TYPE=Vector3d, MEMBER=point, PARENT=ConstraintSet)%
-#    %VectorWrapperAddProperty (TYPE=Vector3d, MEMBER=normal, PARENT=ConstraintSet)%
-
-#    property acceleration:
-#        def __get__(self):
-#            return VectorNd.fromPointer (<uintptr_t> &(self.thisptr.acceleration)).toNumpy()
-#        def __set__(self, values):
-#            vec = VectorNd.fromPythonArray (values)
-#            self.thisptr.acceleration = <crbdl.VectorNd> (vec.thisptr[0])
 
 ##############################
 #

--- a/python/rbdl_loadmodel.cc
+++ b/python/rbdl_loadmodel.cc
@@ -15,28 +15,28 @@ using namespace RigidBodyDynamics;
 using namespace std;
 
 bool rbdl_loadmodel (const char* filename, Model* model, bool floating_base=false, bool verbose=false) {
-	string fname (filename);
+  string fname (filename);
 
-	for (size_t i = 0; i < fname.size(); i++) {
-		fname[i] = tolower(fname[i]);
-	}
+  for (size_t i = 0; i < fname.size(); i++) {
+    fname[i] = tolower(fname[i]);
+  }
 
-	bool result = false;
-	if (fname.substr (fname.size() - 4, 4) == ".lua") {
+  bool result = false;
+  if (fname.substr (fname.size() - 4, 4) == ".lua") {
 #ifdef RBDL_BUILD_ADDON_LUAMODEL
-		result = Addons::LuaModelReadFromFile (filename, model, verbose);	
+    result = Addons::LuaModelReadFromFile (filename, model, verbose);  
 #else
-		cerr << "Error: RBDL Addon LuaModel not enabled!" << endl;
+    cerr << "Error: RBDL Addon LuaModel not enabled!" << endl;
 #endif
-	} else if (fname.substr (fname.size() - 5, 5) == ".urdf") {
+  } else if (fname.substr (fname.size() - 5, 5) == ".urdf") {
 #ifdef RBDL_BUILD_ADDON_URDFREADER
-		result = Addons::URDFReadFromFile (filename, model, floating_base, verbose);	
+    result = Addons::URDFReadFromFile (filename, model, floating_base, verbose);  
 #else
-		cerr << "Error: RBDL Addon URDFReader not enabled!" << endl;
+    cerr << "Error: RBDL Addon URDFReader not enabled!" << endl;
 #endif
-	} else {
-		cerr << "Error: Cannot identify model type from filename '" << filename << "'!" << endl;
-	}
+  } else {
+    cerr << "Error: Cannot identify model type from filename '" << filename << "'!" << endl;
+  }
 
-	return result;
+  return result;
 }

--- a/python/rbdl_ptr_functions.h
+++ b/python/rbdl_ptr_functions.h
@@ -520,7 +520,7 @@ void NonlinearEffectsPtr (
     if (model.lambda[i] == 0) {
       model.v[i] = model.v_J[i];
       model.a[i] = model.X_lambda[i].apply(spatial_gravity);
-    }	else {
+    }  else {
       model.v[i] = model.X_lambda[i].apply(model.v[model.lambda[i]]) + model.v_J[i];
       model.c[i] = model.c_J[i] + crossm(model.v[i],model.v_J[i]);
       model.a[i] = model.X_lambda[i].apply(model.a[model.lambda[i]]) + model.c[i];
@@ -980,8 +980,8 @@ RBDL_DLLAPI bool InverseKinematicsPtr (
   assert (body_id.size() == target_pos.size());
 
 //  for (unsigned int k = 0; k < body_id.size(); k++) {
-//			assert(model.IsBodyId (body_id[k]));
-//	}
+//      assert(model.IsBodyId (body_id[k]));
+//  }
 
 
   VectorNdRef&& Qinit = VectorFromPtr(const_cast<double*>(qinit_ptr),

--- a/python/test_wrapper.py
+++ b/python/test_wrapper.py
@@ -18,7 +18,7 @@ class JointTests (unittest.TestCase):
 
         axis = np.asarray([[1., 0., 0., 0., 0., 0.]])
         joint_rot_x = rbdl.Joint.fromJointAxes (axis)
-        joint_rot_x_type = rbdl.Joint.fromJointType (rbdl.PJointType.PJointTypeRevoluteX)
+        joint_rot_x_type = rbdl.Joint.fromJointType ("JointTypeRevoluteX")
         
         assert_equal (joint_rot_x.getJointAxis(0), axis[0])
         assert_equal (joint_rot_x_type.getJointAxis(0), axis[0])
@@ -37,7 +37,7 @@ class JointTests (unittest.TestCase):
             ])
             
         joint = rbdl.Joint.fromJointAxes (axis)
-        joint2 = rbdl.Joint.fromJointType (rbdl.PJointType.PJointTypeFloatingBase)
+        joint2 = rbdl.Joint.fromJointType ("JointTypeFloatingBase")
 
         
         for i in range (axis.shape[0]):
@@ -53,7 +53,7 @@ class SampleModel3R (unittest.TestCase):
     def setUp(self):
       
         self.model = rbdl.Model()
-        joint_rot_y = rbdl.Joint.fromJointType (rbdl.PJointType.PJointTypeRevoluteY)
+        joint_rot_y = rbdl.Joint.fromJointType ("JointTypeRevoluteY")
         self.body = rbdl.Body.fromMassComInertia (1., np.array([0., 0.0, 0.5]), np.eye(3) *
                 0.05)
         self.xtrans = rbdl.SpatialTransform()
@@ -67,6 +67,31 @@ class SampleModel3R (unittest.TestCase):
         self.qdot = np.zeros (self.model.qdot_size)
         self.qddot = np.zeros (self.model.qdot_size)
         self.tau = np.zeros (self.model.qdot_size)
+
+    def test_AccessToModelParameters (self):
+        """
+        Checks whether vital model parameters can be accessed that are 
+        stored in the "Model" class.
+        """    
+        rbdl.UpdateKinematics (self.model, self.q, self.qdot, self.qddot)
+        
+        assert_equal (self.model.mBodies[2].mMass, self.body.mMass)
+        assert_equal (self.model.mBodies[2].mCenterOfMass, 
+                                        self.body.mCenterOfMass)
+        assert_equal (self.model.mBodies[2].mInertia, 
+                                        self.body.mInertia )
+                                        
+        assert_equal (self.model.X_T[1].E, rbdl.SpatialTransform().E )
+        assert_equal (self.model.X_T[1].r, rbdl.SpatialTransform().r )
+        assert_equal (self.model.X_T[2].E, self.xtrans.E )
+        assert_equal (self.model.X_T[2].r, self.xtrans.r )
+        
+        assert_almost_equal (self.model.X_base[0].E, np.identity(3) )
+        assert_almost_equal (self.model.X_base[3].r, 
+                                        self.xtrans.r + self.xtrans.r )
+        
+        assert_equal (self.model.mJoints[2].mJointType, 
+                                                "JointTypeRevoluteY")
 
     def test_CoordinateTransformBodyBase (self):
         """
@@ -328,7 +353,7 @@ class SampleModel3R (unittest.TestCase):
         with CalcPointVelocity. """
 
         self.model = rbdl.Model()
-        joint_trans_xyz = rbdl.Joint.fromJointType (rbdl.PJointType.PJointTypeTranslationXYZ)
+        joint_trans_xyz = rbdl.Joint.fromJointType ("JointTypeTranslationXYZ")
 
         self.body_1 = self.model.AppendBody (rbdl.SpatialTransform(),
                 joint_trans_xyz, self.body)
@@ -405,13 +430,14 @@ class SampleModel3R (unittest.TestCase):
         assert_almost_equal (target_positions[0], res_point2)
         assert_almost_equal (ori_matrix, res_ori)
 
+
 class FloatingBaseModel (unittest.TestCase):
     """ Model with a floating base
     """
     def setUp(self):
       
         self.model = rbdl.Model()
-        joint_rot_y = rbdl.Joint.fromJointType (rbdl.PJointType.PJointTypeFloatingBase)
+        joint_rot_y = rbdl.Joint.fromJointType ("JointTypeFloatingBase")
         self.body = rbdl.Body.fromMassComInertia (1., np.array([0., 0.0, 0.5]), np.eye(3) *
                 0.05)
         self.xtrans = rbdl.SpatialTransform()
@@ -763,7 +789,6 @@ class ConstraintSetTests (unittest.TestCase):
         assert_equal(0,gId)
         gId = self.cs.getGroupIndexByAssignedId(0)
         assert_equal(0,gId)
-
         gId = self.cs.getGroupIndexByName("LoopLink1Link2")
         assert_equal(1,gId)
         gId = self.cs.getGroupIndexById(11)

--- a/python/wrappergen.py
+++ b/python/wrappergen.py
@@ -43,160 +43,11 @@ wrapper_command_strings = {
     
     "AddProperty" : """    property %MEMBER%:
         def __get__ (self):
-                return self.%MEMBER%
+            vector_size = self.thisptr.%MEMBER%.size()
+            prop = [%TYPE% (address=<uintptr_t> &(self.thisptr.%MEMBER%[i])) for i in range(vector_size)]
+            return prop
 """
 }
-
-type_properties = {
-  
-    "SpatialTransform" : """    property %MEMBER%:
-        def __get__ (self):
-            vector_size = self.thisptr.%MEMBER%.size()
-            ST = [SpatialTransform() for i in range(vector_size)]
-            for k in range(vector_size):
-              for i in range (self.thisptr.%MEMBER%[k].r.rows()):
-                ST[k].r[i] = self.thisptr.%MEMBER%[k].r[i]
-              for i in range (self.thisptr.%MEMBER%[k].E.rows()):
-                  for j in range (self.thisptr.%MEMBER%[k].E.cols()):
-                      ST[k].E[i,j] = self.thisptr.%MEMBER%[k].E.coeff(i,j)
-            return ST
-""",
-
-  "SpatialVector" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-              ST[k][i] = self.thisptr.%MEMBER%[k][i]
-          return ST
-""",
-
-  "VectorNd" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-              ST[k][i] = self.thisptr.%MEMBER%[k][i]
-          return ST
-""",
-
-"Vector2d" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-              ST[k][i] = self.thisptr.%MEMBER%[k][i]
-          return ST
-""",
-
-  "Vector3d" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-              ST[k][i] = self.thisptr.%MEMBER%[k][i]
-          return ST
-""",
-                
-    "SpatialMatrix" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-                for j in range (self.thisptr.%MEMBER%[k].cols()):
-                    ST[k][i,j] = self.thisptr.%MEMBER%[k].coeff(i,j)
-          return ST
-
-""",
-
-
-    "MatrixNd" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-                for j in range (self.thisptr.%MEMBER%[k].cols()):
-                    ST[k][i,j] = self.thisptr.%MEMBER%[k].coeff(i,j)
-          return ST
-
-""",
-
-    "Matrix3d" :  """    property %MEMBER%:
-      def __get__ (self):
-          vector_size = self.thisptr.%MEMBER%.size()
-          ST = [%TYPE%() for i in range(vector_size)]
-          for k in range(vector_size):
-            for i in range (self.thisptr.%MEMBER%[k].rows()):
-                for j in range (self.thisptr.%MEMBER%[k].cols()):
-                    ST[k][i,j] = self.thisptr.%MEMBER%[k].coeff(i,j)
-          return ST
-
-""",
-
-    "SpatialRigidBodyInertia" : """    property %MEMBER%:
-        def __get__ (self):
-            vector_size = self.thisptr.%MEMBER%.size()
-            ST = [%TYPE%() for i in range(vector_size)]
-            for k in range(vector_size):
-              ST[k].m = self.thisptr.%MEMBER%[k].m
-              ST[k].Ixx = self.thisptr.%MEMBER%[k].Ixx
-              ST[k].Iyx = self.thisptr.%MEMBER%[k].Iyx
-              ST[k].Iyy = self.thisptr.%MEMBER%[k].Iyy
-              ST[k].Izx = self.thisptr.%MEMBER%[k].Izx
-              ST[k].Izy = self.thisptr.%MEMBER%[k].Izy
-              ST[k].Izz = self.thisptr.%MEMBER%[k].Izz
-              for i in range (self.thisptr.%MEMBER%[k].h.rows()):
-                ST[k].h[i] = self.thisptr.%MEMBER%[k].h[i]
-            return ST
-""",
-    
-    "Body" : """    property %MEMBER%:
-        def __get__ (self):
-            vector_size = self.thisptr.%MEMBER%.size()
-            ST = [%TYPE%() for i in range(vector_size)]
-            for k in range(vector_size):
-              ST[k].mMass = self.thisptr.%MEMBER%[k].mMass
-              for i in range (self.thisptr.%MEMBER%[k].mCenterOfMass.rows()):
-                ST[k].mCenterOfMass[i] = self.thisptr.%MEMBER%[k].mCenterOfMass[i]
-              for i in range (self.thisptr.%MEMBER%[k].mInertia.rows()):
-                  for j in range (self.thisptr.%MEMBER%[k].mInertia.cols()):
-                      ST[k].mInertia[i,j] = self.thisptr.%MEMBER%[k].mInertia.coeff(i,j)
-            return ST
-""",
-
-    "FixedBody" : """    property %MEMBER%:
-        def __get__ (self):
-            vector_size = self.thisptr.%MEMBER%.size()
-            ST = [%TYPE%() for i in range(vector_size)]
-            for k in range(vector_size):
-              ST[k].mMass = self.thisptr.%MEMBER%[k].mMass
-              for i in range (self.thisptr.%MEMBER%[k].mCenterOfMass.rows()):
-                ST[k].mCenterOfMass[i] = self.thisptr.%MEMBER%[k].mCenterOfMass[i]
-              for i in range (self.thisptr.%MEMBER%[k].mInertia.rows()):
-                  for j in range (self.thisptr.%MEMBER%[k].mInertia.cols()):
-                      ST[k].mInertia[i,j] = self.thisptr.%MEMBER%[k].mInertia.coeff(i,j)
-            return ST
-""",
-
-    "Joint" : """    property %MEMBER%:
-        def __get__ (self):
-            vector_size = self.thisptr.%MEMBER%.size()
-            ST = [%TYPE%() for i in range(vector_size)]
-            for k in range(vector_size):
-              ST[k].mDoFCount = self.thisptr.%MEMBER%[k].mDoFCount
-              
-              ST[k].q_index = self.thisptr.%MEMBER%[k].q_index
-            return ST
-"""
-
-}
-
 
 
 def parse_line (line_str):
@@ -255,10 +106,10 @@ if __name__ == "__main__":
                 generated_parent_members[args["PARENT"]] = []
 
             if command=="AddProperty":
-                generated_parent_members[args["PARENT"]].append ({
-                    "TYPE": args["TYPE"],
-                    "MEMBER": args["MEMBER"]
-                    })
+               generated_parent_members[args["PARENT"]].append ({
+                   "TYPE": args["TYPE"],
+                   "MEMBER": args["MEMBER"]
+                   })
 
 
     # generate code
@@ -267,22 +118,17 @@ if __name__ == "__main__":
         if not command:
             outfile.write (line_str + "\n")
         else:
-           ## print (command, wrapper_command_strings.keys())
             if command in wrapper_command_strings.keys():
                 parent = args["PARENT"]
                 if command == "AddProperty":
                         content_type = args["TYPE"]
                         member_name = args["MEMBER"]
                         command_code = wrapper_command_strings[command][:]
-                        if content_type in type_properties.keys():
-                          command_code = type_properties[content_type][:]
                         command_code = command_code.replace (
                                 "%PARENT%", parent).replace (
                                 "%MEMBER%", member_name).replace (
                                 "%TYPE%", content_type)
                         outfile.write (command_code + "\n")
-                        
-            
                 else:
                     for member in generated_parent_members[parent]:
                         content_type = member["TYPE"]


### PR DESCRIPTION
Solves the issues regarding the python binding of vector class elements to the corresponding python class elements. Their content is now also accessible in python. I also added a small test to "test_wrapper.py" and fixed the tests and property "mJointType" of class "Joint" with respect to the new joint type handling introduced in pull request #29. 
Note that many of the changes are just tab-to-spaces conversions. All changes in the files "crbdl.pxd", "rbdl_loadmodel.cc " and  "rbdl_ptr_functions.h " are  tab-to-spaces conversions.

Closes #35
Closes #36

FYI: The Python test cases for the constraints are failing at the moment. This is probably due to a modified ID assignment during the creation of the constraints. In the tests, the IDs are matched against hard-coded numbers. These hard-coded numbers have to be updated if the ID assignment works as intended. This should best be checked by mjhmilla as he implemented the constraint structure.