### PR TITLE
Add casadi math compile definition

### DIFF
--- a/casadi/CMakeLists.txt
+++ b/casadi/CMakeLists.txt
@@ -2,6 +2,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
 
 FIND_PACKAGE (Casadi REQUIRED)
 
+add_definitions(-DRBDL_USE_CASADI_MATH)
+
 IF (RBDL_STORE_VERSION)
 	# Set versioning information that can be queried during runtime
 	EXECUTE_PROCESS(COMMAND "git" "rev-parse" "HEAD"


### PR DESCRIPTION
Small fix adds the necessary C preprocessor definition so the casadi version will compile with the casadi data structures, rather than the eigen ones.